### PR TITLE
🔧 FH-3990 Call to OpenShift on startup to get server metadata

### DIFF
--- a/pkg/k8s/metadata.go
+++ b/pkg/k8s/metadata.go
@@ -1,0 +1,113 @@
+package k8s
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"encoding/json"
+
+	"github.com/feedhenry/mcp-standalone/pkg/mobile"
+	"github.com/pkg/errors"
+)
+
+type Metadata struct {
+	Issuer                        string   `json:"issuer"`
+	AuthorizationEndpoint         string   `json:"authorization_endpoint"`
+	TokenEndpoint                 string   `json:"token_endpoint"`
+	ScopesSupported               []string `json:"scopes_supported"`
+	ResponseTypesSupported        []string `json:"response_types_supported"`
+	GrantTypesSupported           []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported"`
+}
+
+// GetK8IssuerHost will parse out the host from the meta response
+func (m *Metadata) GetK8IssuerHost() (string, error) {
+	parsed, err := url.Parse(m.Issuer)
+	if err != nil {
+		return "", errors.Wrap(err, "GetK8IssuerHost failed to parse k8s url")
+	}
+	return parsed.Host, nil
+}
+
+func GetMetadata(k8shost string, requester mobile.ExternalHTTPRequester) (*Metadata, error) {
+	url := fmt.Sprintf("%s%s", k8shost, "/.well-known/oauth-authorization-server")
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create request to retrieve OpenShift server metadata")
+	}
+	res, err := requester.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to do request to retrieve OpenShift server metadata")
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		data, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, "attempted to read body after failed OpenShift server metadata call")
+		}
+		if nil != data {
+			return nil, errors.Wrap(err, "unexpected response from OpenShift"+string(data))
+		}
+		return nil, errors.New("unexpected response from OpenShift: " + res.Status)
+	}
+
+	metadata := &Metadata{}
+	decoder := json.NewDecoder(res.Body)
+	if err := decoder.Decode(metadata); err != nil {
+		return nil, errors.Wrap(err, "OpenShift server metadata: Attempted to decode payload")
+	}
+
+	if !checkScopes(*metadata) {
+		return nil, errors.New(fmt.Sprintf("OpenShift server metadata is missing required scopes. Got %v", metadata.ScopesSupported))
+	}
+
+	if !checkResponseTypes(*metadata) {
+		return nil, errors.New(fmt.Sprintf("OpenShift server metadata is missing required response types. Got %v", metadata.ResponseTypesSupported))
+	}
+
+	if !checkGrantTypes(*metadata) {
+		return nil, errors.New(fmt.Sprintf("OpenShift server metadata is missing required grant types. Got %v", metadata.GrantTypesSupported))
+	}
+
+	return metadata, nil
+}
+
+func checkScopes(metadata Metadata) bool {
+	hasUserInfoScope := false
+	hasUserCheckAccessScope := false
+	for _, b := range metadata.ScopesSupported {
+		if !hasUserInfoScope && b == "user:info" {
+			hasUserInfoScope = true
+		}
+		if !hasUserCheckAccessScope && b == "user:check-access" {
+			hasUserCheckAccessScope = true
+		}
+	}
+	return hasUserInfoScope && hasUserCheckAccessScope
+}
+
+func checkResponseTypes(metadata Metadata) bool {
+	hasCodeType := false
+	hasTokenType := false
+	for _, b := range metadata.ResponseTypesSupported {
+		if !hasCodeType && b == "code" {
+			hasCodeType = true
+		}
+		if !hasTokenType && b == "token" {
+			hasTokenType = true
+		}
+	}
+	return hasCodeType && hasTokenType
+}
+
+func checkGrantTypes(metadata Metadata) bool {
+	hasAuthorizationCodeType := false
+	for _, b := range metadata.GrantTypesSupported {
+		if !hasAuthorizationCodeType && b == "authorization_code" {
+			hasAuthorizationCodeType = true
+		}
+	}
+	return hasAuthorizationCodeType
+}

--- a/pkg/k8s/metadata_test.go
+++ b/pkg/k8s/metadata_test.go
@@ -1,0 +1,201 @@
+package k8s
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"bytes"
+	"io/ioutil"
+
+	"fmt"
+
+	"github.com/feedhenry/mcp-standalone/pkg/mock"
+)
+
+func TestGetMetadata(t *testing.T) {
+	cases := []struct {
+		Name            string
+		K8shost         string
+		RequestResponse func(host string, path string, method string, t *testing.T) (*http.Response, error)
+		ExpectError     bool
+		Validate        func(metadata *Metadata, err error, t *testing.T)
+	}{
+		{
+			Name:    "test get metadata ok",
+			K8shost: "https://127.0.0.1:443",
+			RequestResponse: func(host string, path string, method string, t *testing.T) (*http.Response, error) {
+				buf := bytes.NewBufferString(`{
+				  "issuer": "https://mockk8shost.example.com",
+				  "authorization_endpoint": "https://mockk8shost.example.com/oauth/authorize",
+				  "token_endpoint": "https://mockk8shost.example.com/oauth/token",
+				  "scopes_supported": [
+					"user:info",
+					"user:check-access"
+				  ],
+				  "response_types_supported": [
+					"code",
+					"token"
+				  ],
+				  "grant_types_supported": [
+					"authorization_code",
+					"implicit"
+				  ],
+				  "code_challenge_methods_supported": [
+					"plain",
+					"S256"
+				  ]
+				}`)
+				if host == "127.0.0.1:443" && path == "/.well-known/oauth-authorization-server" {
+					return &http.Response{
+						StatusCode: 200,
+						Body:       ioutil.NopCloser(buf),
+					}, nil
+				}
+				return nil, errors.New(fmt.Sprintf("unexpected host or path %s %s ", host, path))
+			},
+			Validate: func(metadata *Metadata, err error, t *testing.T) {
+				if metadata == nil {
+					t.Fatal("expected metadata but got none")
+				}
+				expected := "https://mockk8shost.example.com"
+				if metadata.Issuer != expected {
+					t.Fatalf("expected the metadata host to be '%s' but got '%s'", expected, metadata.Issuer)
+				}
+			},
+		},
+		{
+			Name:    "test get metadata scope missing",
+			K8shost: "https://127.0.0.1:443",
+			RequestResponse: func(host string, path string, method string, t *testing.T) (*http.Response, error) {
+				buf := bytes.NewBufferString(`{
+				  "issuer": "https://mockk8shost.example.com",
+				  "authorization_endpoint": "https://mockk8shost.example.com/oauth/authorize",
+				  "token_endpoint": "https://mockk8shost.example.com/oauth/token",
+				  "scopes_supported": [
+					"user:info"
+				  ],
+				  "response_types_supported": [
+					"code",
+					"token"
+				  ],
+				  "grant_types_supported": [
+					"authorization_code",
+					"implicit"
+				  ],
+				  "code_challenge_methods_supported": [
+					"plain",
+					"S256"
+				  ]
+				}`)
+				if host == "127.0.0.1:443" && path == "/.well-known/oauth-authorization-server" {
+					return &http.Response{
+						StatusCode: 200,
+						Body:       ioutil.NopCloser(buf),
+					}, nil
+				}
+				return nil, errors.New(fmt.Sprintf("unexpected host or path %s %s ", host, path))
+			},
+			ExpectError: true,
+			Validate: func(metadata *Metadata, err error, t *testing.T) {
+				expected := "OpenShift server metadata is missing required scopes. Got [user:info]"
+				if err.Error() != expected {
+					t.Fatal(fmt.Sprintf("expected error %s but got %s", expected, err))
+				}
+			},
+		},
+		{
+			Name:    "test get metadata response type missing",
+			K8shost: "https://127.0.0.1:443",
+			RequestResponse: func(host string, path string, method string, t *testing.T) (*http.Response, error) {
+				buf := bytes.NewBufferString(`{
+				  "issuer": "https://mockk8shost.example.com",
+				  "authorization_endpoint": "https://mockk8shost.example.com/oauth/authorize",
+				  "token_endpoint": "https://mockk8shost.example.com/oauth/token",
+				  "scopes_supported": [
+					"user:info",
+					"user:check-access"
+				  ],
+				  "response_types_supported": [
+					"code"
+				  ],
+				  "grant_types_supported": [
+					"authorization_code",
+					"implicit"
+				  ],
+				  "code_challenge_methods_supported": [
+					"plain",
+					"S256"
+				  ]
+				}`)
+				if host == "127.0.0.1:443" && path == "/.well-known/oauth-authorization-server" {
+					return &http.Response{
+						StatusCode: 200,
+						Body:       ioutil.NopCloser(buf),
+					}, nil
+				}
+				return nil, errors.New(fmt.Sprintf("unexpected host or path %s %s ", host, path))
+			},
+			ExpectError: true,
+			Validate: func(metadata *Metadata, err error, t *testing.T) {
+				expected := "OpenShift server metadata is missing required response types. Got [code]"
+				if err.Error() != expected {
+					t.Fatal(fmt.Sprintf("expected error %s but got %s", expected, err))
+				}
+			},
+		},
+		{
+			Name:    "test get metadata grant type missing",
+			K8shost: "https://127.0.0.1:443",
+			RequestResponse: func(host string, path string, method string, t *testing.T) (*http.Response, error) {
+				buf := bytes.NewBufferString(`{
+				  "issuer": "https://mockk8shost.example.com",
+				  "authorization_endpoint": "https://mockk8shost.example.com/oauth/authorize",
+				  "token_endpoint": "https://mockk8shost.example.com/oauth/token",
+				  "scopes_supported": [
+					"user:info",
+					"user:check-access"
+				  ],
+				  "response_types_supported": [
+					"code",
+					"token"
+				  ],
+				  "grant_types_supported": [
+					"implicit"
+				  ],
+				  "code_challenge_methods_supported": [
+					"plain",
+					"S256"
+				  ]
+				}`)
+				if host == "127.0.0.1:443" && path == "/.well-known/oauth-authorization-server" {
+					return &http.Response{
+						StatusCode: 200,
+						Body:       ioutil.NopCloser(buf),
+					}, nil
+				}
+				return nil, errors.New(fmt.Sprintf("unexpected host or path %s %s ", host, path))
+			},
+			ExpectError: true,
+			Validate: func(metadata *Metadata, err error, t *testing.T) {
+				expected := "OpenShift server metadata is missing required grant types. Got [implicit]"
+				if err.Error() != expected {
+					t.Fatal(fmt.Sprintf("expected error %s but got %s", expected, err))
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			metadata, err := GetMetadata(tc.K8shost, &mock.Requester{Responder: tc.RequestResponse})
+			if tc.ExpectError && err == nil {
+				t.Fatal("expected an error but got none")
+			}
+			if !tc.ExpectError && err != nil {
+				t.Fatalf("did not expect an error but got %v ", err)
+			}
+			tc.Validate(metadata, err, t)
+		})
+	}
+}

--- a/pkg/mock/mockRequester.go
+++ b/pkg/mock/mockRequester.go
@@ -1,0 +1,22 @@
+package mock
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+type Requester struct {
+	Test      *testing.T
+	Responder func(host string, path string, method string, t *testing.T) (*http.Response, error)
+}
+
+func (mr *Requester) Do(req *http.Request) (*http.Response, error) {
+	return mr.Responder(req.Host, req.URL.Path, req.Method, mr.Test)
+}
+
+func (mr *Requester) Get(fullUrl string) (*http.Response, error) {
+	parsedUrl, _ := url.Parse(fullUrl)
+
+	return mr.Responder(parsedUrl.Host, parsedUrl.Path, "GET", mr.Test)
+}

--- a/pkg/web/consoleConfigHandler.go
+++ b/pkg/web/consoleConfigHandler.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
-	"net/url"
 )
 
 // ConsoleConfigHandler handle console config route
@@ -72,23 +71,18 @@ type mcpConsoleConfig struct {
 }
 
 // NewConsoleConfigHandler returns a new console config handler
-func NewConsoleConfigHandler(logger *logrus.Logger, consoleMountPath string, k8host string, oauthClientID string) *ConsoleConfigHandler {
-	k8MasterUrlParsed, err := url.Parse(k8host)
-	if err != nil {
-		panic(fmt.Sprintf("Error parsing k8host %v", err))
-	}
-	oauthAuthorizeUri := fmt.Sprintf("%s/oauth/authorize", k8host)
-	oauthTokenUri := fmt.Sprintf("%s/oauth/token", "https://127.0.0.1:3001")
+func NewConsoleConfigHandler(logger *logrus.Logger, consoleMountPath string, k8sHost string, k8sAuthorizeEndpoint string, oauthClientID string) *ConsoleConfigHandler {
+	oauthTokenUri := fmt.Sprintf("%s/oauth/token", "https://127.0.0.1:9000")
 	oauthRedirectBase := fmt.Sprintf("%s/console", "https://127.0.0.1:9000")
 
 	mcpConsoleConfig := mcpConsoleConfig{
-		APIGroupAddr:      k8MasterUrlParsed.Host,
+		APIGroupAddr:      k8sHost,
 		APIGroupPrefix:    "/apis",
-		MasterAddr:        k8MasterUrlParsed.Host,
+		MasterAddr:        k8sHost,
 		MasterPrefix:      "/oapi",
-		KubernetesAddr:    k8MasterUrlParsed.Host,
+		KubernetesAddr:    k8sHost,
 		KubernetesPrefix:  "/api",
-		OAuthAuthorizeURI: oauthAuthorizeUri,
+		OAuthAuthorizeURI: k8sAuthorizeEndpoint,
 		OAuthTokenURI:     oauthTokenUri,
 		OAuthRedirectBase: oauthRedirectBase,
 		OAuthClientID:     oauthClientID,


### PR DESCRIPTION
The metadata is validated to include:
* required scopes
* required response types
* required grant types

The metadata is used to:
* configure the oauth client when requesting tokens
* configure the UI via the /console/config.js endpoint