### PR TITLE
add mobileservice configure end-point and unit tests

### DIFF
--- a/pkg/data/mobileService.go
+++ b/pkg/data/mobileService.go
@@ -43,10 +43,17 @@ func (msr *MobileServiceRepo) List(f mobile.AttrFilterFunc) ([]*mobile.Service, 
 }
 
 func convertSecretToMobileService(s v1.Secret) *mobile.Service {
+	params := map[string]string{}
+	for key, value := range s.Data {
+		if key != "uri" && key != "name" {
+			params[key] = string(value)
+		}
+	}
 	return &mobile.Service{
-		Name:   strings.TrimSpace(string(s.Data["name"])),
-		Host:   string(s.Data["uri"]),
-		Params: map[string]string{},
+		Name:              strings.TrimSpace(string(s.Data["name"])),
+		Host:              string(s.Data["uri"]),
+		BindingSecretName: s.GetName(),
+		Params:            params,
 	}
 }
 
@@ -60,9 +67,9 @@ type MobileServiceRepoBuilder struct {
 }
 
 // WithClient sets the client to use
-func (marb *MobileServiceRepoBuilder) WithClient(c corev1.SecretInterface) mobile.ServiceRepoBuilder {
+func (marb *MobileServiceRepoBuilder) WithClient(client corev1.SecretInterface) mobile.ServiceRepoBuilder {
 	return &MobileServiceRepoBuilder{
-		client: c,
+		client: client,
 	}
 }
 

--- a/pkg/mobile/integration/service.go
+++ b/pkg/mobile/integration/service.go
@@ -3,6 +3,10 @@ package integration
 import (
 	"github.com/feedhenry/mcp-standalone/pkg/mobile"
 	"github.com/pkg/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/pkg/api/v1"
+	v1beta1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
 )
 
 // MobileService holds the business logic for dealing with the mobile services and integrations with those services
@@ -12,9 +16,13 @@ type MobileService struct {
 // DiscoverMobileServices will discover mobile services configured in the current namespace
 func (ms *MobileService) DiscoverMobileServices(serviceCruder mobile.ServiceCruder) ([]*mobile.Service, error) {
 	//todo move to config
-	serviceNames := []string{"fh-sync-server", "keycloak"}
+	return ms.FindByNames([]string{"fh-sync-server", "keycloak"}, serviceCruder)
+}
+
+//FindByNames will return all services with a name that matches the provided name
+func (ms *MobileService) FindByNames(names []string, serviceCruder mobile.ServiceCruder) ([]*mobile.Service, error) {
 	filter := func(att mobile.Attributer) bool {
-		for _, sn := range serviceNames {
+		for _, sn := range names {
 			if sn == att.GetName() {
 				return true
 			}
@@ -27,4 +35,67 @@ func (ms *MobileService) DiscoverMobileServices(serviceCruder mobile.ServiceCrud
 		return nil, errors.Wrap(err, "Attempting to discover mobile services.")
 	}
 	return svc, nil
+}
+
+//MountSecretForComponent will work within namespace and mount secretName into componentName, so it can be configured to use serviceName, returning the modified deployment
+func (ms *MobileService) MountSecretForComponent(k8s kubernetes.Interface, secretName, componentName, serviceName, namespace string) (*v1beta1.Deployment, error) {
+	deploy, err := k8s.AppsV1beta1().Deployments(namespace).Get(componentName, meta_v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	id, err := findContainerID(componentName, deploy.Spec.Template.Spec.Containers)
+	if err != nil {
+		return nil, err
+	}
+
+	//only create the volume if it doesn't exist yet
+	if vol := findVolumeByName(secretName, deploy.Spec.Template.Spec.Volumes); vol.Name != secretName {
+		newVol := v1.Volume{
+			Name: secretName,
+			VolumeSource: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					SecretName: secretName,
+				},
+			},
+		}
+		deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, newVol)
+	}
+
+	if mount := findMountByName(secretName, deploy.Spec.Template.Spec.Containers[id].VolumeMounts); mount.Name != secretName {
+		newMount := v1.VolumeMount{Name: secretName, ReadOnly: true, MountPath: "/etc/secrets/" + serviceName}
+		deploy.Spec.Template.Spec.Containers[id].VolumeMounts = append(deploy.Spec.Template.Spec.Containers[id].VolumeMounts, newMount)
+	}
+
+	k8s.AppsV1beta1().Deployments(namespace).Update(deploy)
+
+	return deploy, nil
+}
+
+func findContainerID(name string, containers []v1.Container) (int, error) {
+	for id, container := range containers {
+		if container.Name == name {
+			return id, nil
+		}
+	}
+	return -1, errors.New("could not find container with name: '" + name + "'")
+}
+
+func findVolumeByName(name string, volumes []v1.Volume) v1.Volume {
+	for _, vol := range volumes {
+		if vol.Name == name {
+			return vol
+		}
+	}
+
+	return v1.Volume{}
+}
+
+func findMountByName(name string, mounts []v1.VolumeMount) v1.VolumeMount {
+	for _, mount := range mounts {
+		if mount.Name == name {
+			return mount
+		}
+	}
+
+	return v1.VolumeMount{}
 }

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -16,9 +16,10 @@ type StatusError struct {
 }
 
 type Service struct {
-	Name   string            `json:"name"`
-	Host   string            `json:"host"`
-	Params map[string]string `json:"params"`
+	Name              string            `json:"name"`
+	Host              string            `json:"host"`
+	Params            map[string]string `json:"params"`
+	BindingSecretName string            `json:"binding_secret_name"`
 }
 
 type AttrFilterFunc func(attrs Attributer) bool

--- a/pkg/web/mobileServicesHandler.go
+++ b/pkg/web/mobileServicesHandler.go
@@ -3,6 +3,7 @@ package web
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/feedhenry/mcp-standalone/pkg/mobile"
@@ -27,6 +28,12 @@ func NewMobileServiceHandler(logger *logrus.Logger, integrationService *integrat
 	}
 }
 
+type mobileServiceConfigurationRequest struct {
+	Component string `json:"component"`
+	Service   string `json:"service"`
+	Namespace string `json:"namespace"`
+}
+
 // List allows you to list mobile services
 func (msh *MobileServiceHandler) List(rw http.ResponseWriter, req *http.Request) {
 	token := req.Header.Get(mobile.AuthHeader)
@@ -43,6 +50,65 @@ func (msh *MobileServiceHandler) List(rw http.ResponseWriter, req *http.Request)
 	}
 	encoder := json.NewEncoder(rw)
 	if err := encoder.Encode(svc); err != nil {
+		handleCommonErrorCases(err, rw, msh.logger)
+		return
+	}
+}
+
+// Configure configures components binding
+func (msh *MobileServiceHandler) Configure(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	token := req.Header.Get(mobile.AuthHeader)
+
+	decoder := json.NewDecoder(req.Body)
+	var conf mobileServiceConfigurationRequest
+	err := decoder.Decode(&conf)
+	if err != nil {
+		handleCommonErrorCases(err, rw, msh.logger)
+		return
+	}
+
+	conf.Component = strings.ToLower(conf.Component)
+	conf.Service = strings.ToLower(conf.Service)
+
+	serviceCruder, err := msh.tokenClientBuilder.MobileServiceCruder(token)
+	if err != nil {
+		handleCommonErrorCases(err, rw, msh.logger)
+		return
+	}
+	services, err := msh.mobileIntegrationService.FindByNames([]string{conf.Service}, serviceCruder)
+	if err != nil {
+		err = errors.Wrap(err, "attempted to list mobile services")
+		handleCommonErrorCases(err, rw, msh.logger)
+		return
+	}
+	if len(services) == 0 {
+		err = errors.New("service to configure not found")
+		handleCommonErrorCases(err, rw, msh.logger)
+		return
+	}
+	components, err := msh.mobileIntegrationService.FindByNames([]string{conf.Component}, serviceCruder)
+	if err != nil {
+		err = errors.Wrap(err, "attempted to list mobile services")
+		handleCommonErrorCases(err, rw, msh.logger)
+		return
+	}
+	if len(components) == 0 {
+		err = errors.New("component to configure not found")
+		handleCommonErrorCases(err, rw, msh.logger)
+		return
+	}
+
+	k8sClient, err := msh.tokenClientBuilder.K8s(token)
+
+	deploy, err := msh.mobileIntegrationService.MountSecretForComponent(k8sClient, services[0].BindingSecretName, conf.Component, conf.Service, conf.Namespace)
+	if err != nil {
+		handleCommonErrorCases(err, rw, msh.logger)
+		return
+	}
+
+	encoder := json.NewEncoder(rw)
+	if err := encoder.Encode(deploy); err != nil {
 		handleCommonErrorCases(err, rw, msh.logger)
 		return
 	}

--- a/pkg/web/mobileServicesHandler_test.go
+++ b/pkg/web/mobileServicesHandler_test.go
@@ -2,8 +2,10 @@ package web_test
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,7 +19,9 @@ import (
 	"github.com/feedhenry/mcp-standalone/pkg/mobile/integration"
 	"github.com/feedhenry/mcp-standalone/pkg/mock"
 	"github.com/feedhenry/mcp-standalone/pkg/web"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/pkg/api/v1"
+	v1beta1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
 	ktesting "k8s.io/client-go/testing"
 )
 
@@ -103,6 +107,97 @@ func TestListMobileServices(t *testing.T) {
 					t.Fatal("unexpected error decoding the services response ", err)
 				}
 				tc.Validate(svs, t)
+			}
+		})
+	}
+}
+
+func TestConfigure(t *testing.T) {
+	cases := []struct {
+		Name       string
+		Client     func() kubernetes.Interface
+		StatusCode int
+		Validate   func(r *http.Response, t *testing.T)
+	}{
+		{
+			Name: "test configuring fh-sync-server for keycloak",
+			Client: func() kubernetes.Interface {
+				client := &fake.Clientset{}
+				client.AddReactor("list", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+					return true, &v1.SecretList{
+						Items: []v1.Secret{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "fh-sync-server-secret",
+								},
+								Data: map[string][]byte{
+									"uri":  []byte("http://test.com"),
+									"name": []byte("fh-sync-server"),
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "keycloak-secret",
+								},
+								Data: map[string][]byte{
+									"uri":  []byte("http://test.com"),
+									"name": []byte("keycloak"),
+								},
+							},
+						}}, nil
+				})
+				client.AddReactor("get", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+					return true, &v1beta1.Deployment{
+						Spec: v1beta1.DeploymentSpec{
+							Template: v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									Volumes: []v1.Volume{},
+									Containers: []v1.Container{
+										{
+											Name:         "fh-sync-server",
+											VolumeMounts: []v1.VolumeMount{},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				})
+				return client
+			},
+			StatusCode: http.StatusOK,
+			Validate: func(r *http.Response, t *testing.T) {
+				bodyBytes, _ := ioutil.ReadAll(r.Body)
+				res := &v1beta1.Deployment{}
+				err := json.Unmarshal(bodyBytes, res)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if len(res.Spec.Template.Spec.Volumes) == 0 {
+					t.Fatal("Expected a volume to be added to the deployment")
+				}
+				if len(res.Spec.Template.Spec.Containers[0].VolumeMounts) == 0 {
+					t.Fatal("Expected a volumemount to be added to the container in the deployment")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			handler := setupMobileServiceHandler(tc.Client())
+			server := httptest.NewServer(handler)
+			defer server.Close()
+			res, err := http.Post(server.URL+"/mobileservice/configure", "text/plain", strings.NewReader("{\"component\": \"fh-sync-server\", \"service\": \"keycloak\", \"namespace\": \"myproject\"}"))
+			if err != nil {
+				t.Fatal("did not expect an error requesting mobile services ", err)
+			}
+			if tc.StatusCode != res.StatusCode {
+				t.Fatalf("expected a response code of %d but got %d ", tc.StatusCode, res.StatusCode)
+			}
+			if nil != tc.Validate {
+				tc.Validate(res, t)
 			}
 		})
 	}

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -80,6 +80,7 @@ func SysRoute(r *mux.Router, handler *SysHandler) {
 // MobileServiceRoute configures and sets up the /mobileservice routes
 func MobileServiceRoute(r *mux.Router, handler *MobileServiceHandler) {
 	r.HandleFunc("/mobileservice", prometheus.InstrumentHandlerFunc("mobileservices list", handler.List)).Methods("GET")
+	r.HandleFunc("/mobileservice/configure", prometheus.InstrumentHandlerFunc("mobileservices configuration", handler.Configure)).Methods("POST")
 }
 
 //TODO maybe better place to put this


### PR DESCRIPTION
Added a new endpoint:
```
POST /mobileservice/configure
```
Expecting a JSON post body like:
```
{
    "component": "<component to configure>",
    "service": "<service to configure component to use>",
    "namespace": "<the namespace these are in>"
}
```

This will find the binding secret for `service` and mount it as a volume into `component` under `/etc/secrets<service-name>`, unless it has already been mounted.