### PR TITLE
🔧 FH-4002 Set the oauth redirect config dynamically based on the Request headers

### DIFF
--- a/cmd/mcp-standalone/main.go
+++ b/cmd/mcp-standalone/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/feedhenry/mcp-standalone/pkg/web"
 	"github.com/feedhenry/mcp-standalone/pkg/web/middleware"
 	"github.com/pkg/errors"
-	"golang.org/x/oauth2"
 )
 
 func main() {
@@ -78,20 +77,7 @@ func main() {
 	//oauth handler
 	var oauthClientID = fmt.Sprintf("system:serviceaccount:%s:mcp-standalone", *namespace)
 	{
-		kubernetesOauthEndpoint := &oauth2.Endpoint{
-			AuthURL:  k8sMetadata.AuthorizationEndpoint,
-			TokenURL: k8sMetadata.TokenEndpoint,
-		}
-
-		kubernetesOauthConfig := &oauth2.Config{
-			// TODO: how to dynamically configure this url from the Route
-			RedirectURL:  "https://127.0.0.1:9000/console/oauth",
-			ClientID:     oauthClientID,
-			ClientSecret: token,
-			Scopes:       []string{"user:info user:check-access"},
-			Endpoint:     *kubernetesOauthEndpoint,
-		}
-		oauthHandler := web.NewOauthHandler(logger, kubernetesOauthConfig)
+		oauthHandler := web.NewOauthHandler(logger, *k8sMetadata, oauthClientID, token)
 		web.OAuthRoute(router, oauthHandler)
 	}
 

--- a/install/openshift/install.sh
+++ b/install/openshift/install.sh
@@ -1,6 +1,7 @@
-namespace=$1
+#!/bin/sh
+NAMESPACE=$(oc project -q)
 oc create -f dc.json
 oc create -f sa.json
 oc create -f svc.json
 oc create -f route.json
-oc policy add-role-to-user edit system:serviceaccount:${namespace}:mcp-standalone -n ${namespace}
+oc policy add-role-to-user edit system:serviceaccount:${NAMESPACE}:mcp-standalone

--- a/pkg/web/headers/request.go
+++ b/pkg/web/headers/request.go
@@ -1,0 +1,45 @@
+package headers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func ParseBaseUrl(req *http.Request) (string, error) {
+	// Default to the Host header for the hostname
+	// Use the X-Forwarded-Host header value if present
+	splitHost := strings.Split(req.Host, ":")
+	if ho := req.Header.Get("X-Forwarded-Host"); ho != "" {
+		splitHost = strings.Split(ho, ":")
+	}
+	host := splitHost[0]
+
+	// Default to https
+	// Use the X-Forwarded-Proto header value if present
+	proto := "https"
+	if pr := req.Header.Get("X-Forwarded-Proto"); pr != "" {
+		proto = pr
+	}
+
+	// Default to port 443 for https, 80 for http
+	// Use the port from the Host header if present
+	// Use the X-Forwarded-Port header value if present
+	port := "443"
+	if proto == "http" {
+		port = "80"
+	}
+	if len(splitHost) > 1 {
+		port = splitHost[1]
+	}
+	if po := req.Header.Get("X-Forwarded-Port"); po != "" {
+		port = po
+	}
+
+	// Build up a base url in the format: <protocol>://<host>[:port]
+	baseUrl := fmt.Sprintf("%s://%s", proto, host)
+	if port != "443" && port != "80" {
+		baseUrl += ":" + port
+	}
+	return baseUrl, nil
+}

--- a/pkg/web/oAuthHandler.go
+++ b/pkg/web/oAuthHandler.go
@@ -8,26 +8,52 @@ import (
 	"net/http"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/feedhenry/mcp-standalone/pkg/k8s"
+	"github.com/feedhenry/mcp-standalone/pkg/web/headers"
 	"golang.org/x/oauth2"
 )
 
 // OAuthHandler handle oauth actions
 type OAuthHandler struct {
-	logger *logrus.Logger
-	config *oauth2.Config
+	logger        *logrus.Logger
+	k8sMetadata   k8s.Metadata
+	oauthClientID string
+	oauthEndpoint oauth2.Endpoint
+	token         string
 }
 
 // NewOauthHandler returns a new oauth handler
-func NewOauthHandler(logger *logrus.Logger, config *oauth2.Config) *OAuthHandler {
+func NewOauthHandler(logger *logrus.Logger, k8sMetadata k8s.Metadata, oauthClientID string, token string) *OAuthHandler {
 	// OpenShift OAuth requires client id & secret in request parameters
-	oauth2.RegisterBrokenAuthHeaderProvider(config.Endpoint.TokenURL)
+	oauthEndpoint := oauth2.Endpoint{
+		AuthURL:  k8sMetadata.AuthorizationEndpoint,
+		TokenURL: k8sMetadata.TokenEndpoint,
+	}
+	oauth2.RegisterBrokenAuthHeaderProvider(oauthEndpoint.TokenURL)
+
 	return &OAuthHandler{
-		logger: logger,
-		config: config,
+		logger:        logger,
+		k8sMetadata:   k8sMetadata,
+		oauthClientID: oauthClientID,
+		oauthEndpoint: oauthEndpoint,
+		token:         token,
 	}
 }
 
 func (oah *OAuthHandler) OAuthToken(w http.ResponseWriter, r *http.Request) {
+	baseUrl, err := headers.ParseBaseUrl(r)
+	if err != nil {
+		handleCommonErrorCases(err, w, oah.logger)
+	}
+
+	config := &oauth2.Config{
+		RedirectURL:  fmt.Sprintf("%s/console/oauth", baseUrl),
+		ClientID:     oah.oauthClientID,
+		ClientSecret: oah.token,
+		Scopes:       []string{"user:info user:check-access"},
+		Endpoint:     oah.oauthEndpoint,
+	}
+
 	code := r.FormValue("code")
 
 	tr := &http.Transport{
@@ -38,19 +64,16 @@ func (oah *OAuthHandler) OAuthToken(w http.ResponseWriter, r *http.Request) {
 	ctx := context.TODO()
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, sslcli)
 
-	token, err := oah.config.Exchange(ctx, code)
+	token, err := config.Exchange(ctx, code)
 	if err != nil {
 		oah.logger.Error("Code exchange failed with ", err)
-		http.Redirect(w, r, fmt.Sprintf("%s/error?error=code_exchange_failed&error_description=%s", oah.config.RedirectURL, err), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/error?error=code_exchange_failed&error_description=%s", config.RedirectURL, err), http.StatusTemporaryRedirect)
 		return
 	}
 
-	tokenJSON, err := json.Marshal(token)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	encoder := json.NewEncoder(w)
+	if err := encoder.Encode(token); err != nil {
+		handleCommonErrorCases(err, w, oah.logger)
 		return
 	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(tokenJSON)
 }

--- a/web/Gruntfile.js
+++ b/web/Gruntfile.js
@@ -457,7 +457,6 @@ module.exports = function (grunt) {
           src: [
             '*.{ico,png,txt}',
             '*.html',
-            'config.js',
             'images/{,*/}*.{webp}',
             'styles/fonts/{,*/}*.*'
           ]


### PR DESCRIPTION
This change fixes #11.

* Move the oauth config setup into the oauth handler, and construct it per request
* Use the Request Host (or the X-Forwarded-* headers) as the oauth redirect base url for
	* the oauth/token endpoint
        * the config.js endpoint

NOTE: To run in OpenShift, the following change is required to master-config.yaml, and the master restarted

```yaml
corsAllowedOrigins:
- ".*"
```

TODO:
* [x] figure out why the AuthService in origin-web-common results in a CORS error when discovering the API (doesn't happen locally, only when deployed in OpenShift with a Route in front of the mcp-standalone service/pod)