### PR TITLE
✨ FH-3812 Show url & credentials on service dashboard

### DIFF
--- a/ui/public/scripts/controllers/mobileservice.js
+++ b/ui/public/scripts/controllers/mobileservice.js
@@ -37,6 +37,7 @@ angular.module('mobileControlPanelApp').controller('MobileServiceController', [
     mcpApi
       .mobileApps()
       .then(apps => {
+        $scope.mobileappsCount = apps.length;
         $scope.mobileapps = {};
         for (var i = 0; i < apps.length; i++) {
           let app = apps[i];

--- a/ui/public/styles/main.less
+++ b/ui/public/styles/main.less
@@ -92,7 +92,7 @@ h1.contains-actions {
   border-bottom-style: solid;
 }
 
-.mobile-content h2.card-pf-title {
+.mobile-content h2.card-pf-title, .empty-state-message h2 {
   border:none;
 }
 
@@ -103,6 +103,6 @@ h1.contains-actions {
   margin-top: 20px;
 }
 
-.mobile-content .nav a, .mobile-content .form-group label {
+.mobile-content .nav a, .mobile-content .form-group label, .mobile-content dt {
   text-transform: capitalize;
 }

--- a/ui/public/views/mobileservice.html
+++ b/ui/public/views/mobileservice.html
@@ -23,13 +23,37 @@
               <uib-tabset>
                 <uib-tab active="selectedTab.dashboard" ng-if="service">
                   <uib-tab-heading>Dashboard</uib-tab-heading>
-                  <p>
-                    {{service.Description}}
-                  </p>
+                  <dl class="dl-horizontal left">
+                    <dt>Description:</dt>
+                    <dd>{{ service.description }}</dd>
+                    <dt>Dashboard URL:</dt>
+                    <dd><a href="{{ service.host }}">{{service.host}}</a></dd>
+                    <dt ng-repeat-start="(key, value) in service.params">{{ key }}</dt>
+                    <dd ng-repeat-end>{{ value }}</dd>
+                  </dl>
                 </uib-tab>
                 <uib-tab active="selectedTab.integrations" ng-if="service">
                   <uib-tab-heading>Integrations</uib-tab-heading>
-                    <h2 ng-if="integrations.length > 0">Mobile Service Integrations</h2>
+                  <div ng-if="integrations.length === 0">
+                    <div class="empty-state-message text-center">
+                      <h2>This Service doesn't have any Mobile Integrations available.</h2>
+                    </div>
+                  </div>
+
+                  <div ng-if="integrations.length > 0 && mobileappsCount === 0">
+                    <div class="empty-state-message text-center">
+                      <h2>Get started with Mobile Integrations.</h2>
+                      <p class="gutter-top">
+                      Create a Mobile App to integrate with this Service.
+                      </p>
+                      <p>
+                        <a ng-href="project/{{ projectName }}/create-mobileapp" class="btn btn-primary btn-lg">Create Mobile App</a>
+                      </p>
+                    </div>
+                  </div>
+
+                  <div ng-if="integrations.length > 0 && mobileappsCount > 0">
+                    <h2 >Mobile Service Integrations</h2>
                     <form class="form-horizontal">
                       <div class="form-group" ng-repeat="(key, value) in service.integrations">
                         <label class="col-sm-2 control-label" for="integration-{{key}}">{{key}}</label>
@@ -184,16 +208,17 @@ sync client and keycloak common use case functionality </pre>
                         </tbody>
                       </table>
                     </div>
+                  </div>
 
-                    <script>
-                      setTimeout(function() {
-                        var bswitch = jQuery(".bootstrap-switch");
-                        if (bswitch.length === 1) {
-                          bswitch.bootstrapSwitch();
-                        }
-                      }, 10);
-                      prettyPrint();
-                    </script>
+                  <script>
+                    setTimeout(function() {
+                      var bswitch = jQuery(".bootstrap-switch");
+                      if (bswitch.length === 1) {
+                        bswitch.bootstrapSwitch();
+                      }
+                    }, 10);
+                    prettyPrint();
+                  </script>
                 </uib-tab>
               </uib-tabset>
             </div>


### PR DESCRIPTION
To support this change, the keycloak 'service' will use the
'keycloak-admin' secret, which has the admin credentials.
These credentials will show on the Service Dashboard page.
This is done in a generic way that should work for custom/external services.

![image](https://user-images.githubusercontent.com/878251/30218398-dfebd6ac-94b0-11e7-85ee-6bb67c1019b8.png)

![image](https://user-images.githubusercontent.com/878251/30218402-e27e6b64-94b0-11e7-88b3-884bc85461bd.png)


Empty state checking is added for the integrations section on the same page