### PR TITLE
update keycloak secret name/type and fix some minor code issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-cmd/mcp-standalone/mcp-standalone
+cmd/mcp-api/mcp-api
 token
-mcp-standalone
 mcp
 mcp-api
+web/app/bower_components
+web/dist
+web/node_modules

--- a/pkg/data/mobileApp.go
+++ b/pkg/data/mobileApp.go
@@ -150,6 +150,7 @@ func (mar *MobileAppRepo) readUnderlyingConfigMap(a *mobile.App) (*v1.ConfigMap,
 	return cm, nil
 }
 
+//NewMobileAppRepoBuilder creates a new instance of a MobileAppRepoBuilder
 func NewMobileAppRepoBuilder() mobile.AppRepoBuilder {
 	return &MobileAppRepoBuilder{}
 }

--- a/pkg/data/mobileService.go
+++ b/pkg/data/mobileService.go
@@ -14,6 +14,7 @@ import (
 	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
+// SecretConvertor converts a kubernetes secret into a mobile.ServiceConfig
 type SecretConvertor interface {
 	Convert(s v1.Secret) (*mobile.ServiceConfig, error)
 }
@@ -27,6 +28,7 @@ type MobileServiceValidator interface {
 // defaultSecretConvertor will provide a default secret to config conversion
 type defaultSecretConvertor struct{}
 
+//Convert a kubernetes secret to a mobile.ServiceConfig
 func (dsc defaultSecretConvertor) Convert(s v1.Secret) (*mobile.ServiceConfig, error) {
 	conf := map[string]string{}
 	for k, v := range s.Data {
@@ -40,11 +42,12 @@ func (dsc defaultSecretConvertor) Convert(s v1.Secret) (*mobile.ServiceConfig, e
 
 type keycloakSecretConvertor struct{}
 
+//Convert a kubernetes keycloak secret into a keycloak mobile.ServiceConfig
 func (ksc keycloakSecretConvertor) Convert(s v1.Secret) (*mobile.ServiceConfig, error) {
 	kc := &mobile.KeycloakConfig{}
 	err := json.Unmarshal(s.Data["installation"], kc)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshalal keycloak configuration ")
+		return nil, errors.Wrap(err, "failed to unmarshall keycloak configuration ")
 	}
 	return &mobile.ServiceConfig{
 		Config: kc,
@@ -56,15 +59,13 @@ type secretAttributer struct {
 	*v1.Secret
 }
 
+//GetName returns the value of the name field in the secret
 func (sa *secretAttributer) GetName() string {
 	var name = strings.TrimSpace(string(sa.Secret.Data["name"]))
-	if "" == name {
-		//remove once we fix keycloak apb
-		name = strings.TrimSpace(string(sa.Secret.Data["NAME"]))
-	}
 	return name
 }
 
+//GetType returns the value of the type field in the secret
 func (sa *secretAttributer) GetType() string {
 	return strings.TrimSpace(string(sa.Secret.Data["type"]))
 }

--- a/pkg/mobile/integration/service.go
+++ b/pkg/mobile/integration/service.go
@@ -60,8 +60,8 @@ func (ms *MobileService) DiscoverMobileServices(serviceCruder mobile.ServiceCrud
 	return svc, nil
 }
 
-// ReadMoileServiceAndIntegrations read servuce and any available service it can integrate with
-func (ms *MobileService) ReadMoileServiceAndIntegrations(serviceCruder mobile.ServiceCruder, name string) (*mobile.Service, error) {
+// ReadMobileServiceAndIntegrations read servuce and any available service it can integrate with
+func (ms *MobileService) ReadMobileServiceAndIntegrations(serviceCruder mobile.ServiceCruder, name string) (*mobile.Service, error) {
 	//todo move to config
 	svc, err := serviceCruder.Read(name)
 	if err != nil {
@@ -119,7 +119,7 @@ func (ms *MobileService) GenerateMobileServiceConfigs(serviceCruder mobile.Servi
 //MountSecretForComponent will mount secret into component, returning any errors
 func (ms *MobileService) MountSecretForComponent(svcCruder mobile.ServiceCruder, mounter mobile.VolumeMounter, clientService, serviceSecret string) error {
 	//check secret exists and store for later update
-	service, err := svcCruder.Read("keycloak-public-client")
+	service, err := svcCruder.Read(serviceSecret)
 	if err != nil {
 		return errors.Wrap(err, "failed to find secret: '"+serviceSecret+"'")
 	}

--- a/pkg/mock/data.go
+++ b/pkg/mock/data.go
@@ -8,6 +8,7 @@ func KeycloakSecret() v1.Secret {
 	return v1.Secret{
 		Data: map[string][]byte{
 			"name":         []byte("keycloak"),
+			"type":         []byte("keycloak"),
 			"uri":          []byte("http://keycloak.com"),
 			"installation": []byte("{\"ssl-required\": \"external\", \"auth-server-url\": \"http://keycloak-authmobile.192.168.37.1.nip.io/auth\", \"realm\": \"authmobile\", \"resource\": \"zlFwvnNrkRnBOfeuUVss\", \"credentials\": {\"secret\": \"m3onpFzg2xSm0K4Hze83\"}}"),
 		},

--- a/pkg/web/mobileServicesHandler.go
+++ b/pkg/web/mobileServicesHandler.go
@@ -52,6 +52,7 @@ func (msh *MobileServiceHandler) List(rw http.ResponseWriter, req *http.Request)
 	}
 }
 
+// Read details of a specific service provided in the name URL parameter
 func (msh *MobileServiceHandler) Read(rw http.ResponseWriter, req *http.Request) {
 	token := headers.DefaultTokenRetriever(req.Header)
 	params := mux.Vars(req)
@@ -71,7 +72,7 @@ func (msh *MobileServiceHandler) Read(rw http.ResponseWriter, req *http.Request)
 
 	if withIntegrations != "" {
 		fmt.Println("with Integrations", serviceName)
-		ms, err = msh.mobileIntegrationService.ReadMoileServiceAndIntegrations(serviceCruder, serviceName)
+		ms, err = msh.mobileIntegrationService.ReadMobileServiceAndIntegrations(serviceCruder, serviceName)
 		if err != nil {
 			handleCommonErrorCases(err, rw, msh.logger)
 			return


### PR DESCRIPTION
- update keycloak secret name, related: https://github.com/feedhenry/keycloak-apb/pull/6
- missing entries in `.gitignore`
- missing godocs
- rename typo in function `ReadMoileServiceAndIntegrations` > `ReadMobileServiceAndIntegrations`
- Remove hardcoded `keycloak-public-client` string from old debugging