### PR TITLE
🐳 Use paths under ./ui for OpenShift data dirs

### DIFF
--- a/installer/roles/oc-cluster-up/tasks/main.yml
+++ b/installer/roles/oc-cluster-up/tasks/main.yml
@@ -40,6 +40,15 @@
     - host_config_dir != ''
 
   - set_fact:
+      cluster_up_command: "{{ cluster_up_command }} --host-data-dir={{ host_config_dir }}/openshift-data"
+
+  - set_fact:
+      cluster_up_command: "{{ cluster_up_command }} --host-pv-dir={{ host_config_dir }}/openshift-pvs"
+
+  - set_fact:
+      cluster_up_command: "{{ cluster_up_command }} --host-volumes-dir={{ host_config_dir }}/openshift-volumes"
+
+  - set_fact:
       cluster_up_command: "{{ cluster_up_command }} --use-existing-config={{ use_existing_config }}"
     when:
     - use_existing_config is defined

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -3,3 +3,6 @@ dist/
 master/
 node-localhost/
 node_modules/
+openshift-data/
+openshift-pvs/
+openshift-volumes/

--- a/ui/clean.sh
+++ b/ui/clean.sh
@@ -11,3 +11,7 @@ SCRIPT_ABSOLUTE_PATH=$(cd $SCRIPT_PATH && pwd)
 
 sudo rm -rf ${SCRIPT_ABSOLUTE_PATH}/master
 sudo rm -rf ${SCRIPT_ABSOLUTE_PATH}/node-localhost
+sudo rm -rf ${SCRIPT_ABSOLUTE_PATH}/openshift-data
+sudo rm -rf ${SCRIPT_ABSOLUTE_PATH}/openshift-pvs
+sudo rm -rf ${SCRIPT_ABSOLUTE_PATH}/openshift-volumes
+


### PR DESCRIPTION
This change configures `oc cluster up` to use dirs under the 'ui'
folder, similar to the `--host-config-dir`, for below

- `--host-data-dir` ./ui/openshift-data
- `--host-pv-dir` ./ui/openshift-pvs
- `--host-volumes-dir` ./ui/openshift-volumes

This allows for 2 things:
- easier cleanup of an oc cluster by running the clean.sh script
(Removes PV data too)
- data storage for PV/Volumes/Data is kept where the repo is cloned.
-- this change helps with a standard enough linux setup where the docker
storage may be on the same mount point as the default location for these
`oc cluster` things. This could lead to low disk space after using
docker & openshift for a while. Using the setup in this commit will
allow more space for docker stuff, and keep the openshift stuff separate