### PR TITLE
FH-4070 Remove API Keys on app delete

### DIFF
--- a/pkg/data/mobileApp.go
+++ b/pkg/data/mobileApp.go
@@ -37,7 +37,7 @@ func NewMobileAppRepo(c corev1.ConfigMapInterface, v MobileAppValidator) *Mobile
 	return rep
 }
 
-// UpdateAppApiKeys adds new app api key to config map
+// UpdateAppApiKeys adds new app api key to apiKey mapping
 func (mar *MobileAppRepo) UpdateAppAPIKeys(app *mobile.App) error {
 	cm, err := mar.client.Get(apiKeyMapName, meta_v1.GetOptions{})
 	if err != nil {
@@ -48,7 +48,23 @@ func (mar *MobileAppRepo) UpdateAppAPIKeys(app *mobile.App) error {
 	}
 	cm.Data[app.ID] = app.APIKey
 	if _, err := mar.client.Update(cm); err != nil {
-		return errors.Wrap(err, "updating api key, could not save config map")
+		return errors.Wrap(err, "updating api key map, could not save map")
+	}
+	return nil
+}
+
+// DeleteAppAPIKey remove api key from apiKey mapping
+func (mar *MobileAppRepo) RemoveAppAPIKeyByID(appID string) error {
+	cm, err := mar.client.Get(apiKeyMapName, meta_v1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "deleting api key map, could not read")
+	}
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	delete(cm.Data, appID)
+	if _, err := mar.client.Update(cm); err != nil {
+		return errors.Wrap(err, "deleting api key map, could not save map")
 	}
 	return nil
 }

--- a/pkg/data/mobileApp.go
+++ b/pkg/data/mobileApp.go
@@ -53,7 +53,7 @@ func (mar *MobileAppRepo) UpdateAppAPIKeys(app *mobile.App) error {
 	return nil
 }
 
-// DeleteAppAPIKey remove api key from apiKey mapping
+// RemoveAppAPIKeyByID remove api key from apiKey mapping
 func (mar *MobileAppRepo) RemoveAppAPIKeyByID(appID string) error {
 	cm, err := mar.client.Get(apiKeyMapName, meta_v1.GetOptions{})
 	if err != nil {

--- a/pkg/data/mobileApp_test.go
+++ b/pkg/data/mobileApp_test.go
@@ -355,6 +355,66 @@ func TestUpdateAppAPIKeys(t *testing.T) {
 	}
 }
 
+func TestRemoveAppAPIKeyByID(t *testing.T) {
+	cases := []struct {
+		Name        string
+		ExpectError bool
+		AppID       string
+		Client      func(t *testing.T) corev1.ConfigMapInterface
+	}{
+		{
+			Name:  "test remove app api key ok",
+			AppID: "anapp",
+			Client: func(t *testing.T) corev1.ConfigMapInterface {
+				c := fake.Clientset{}
+				c.AddReactor("get", "configmaps", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"group": "notmobile"},
+						},
+						Data: map[string]string{
+							"anapp": "anAppKey",
+						},
+					}, nil
+				})
+				c.AddReactor("update", "configmaps", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					configmap := action.(ktesting.UpdateAction).GetObject().(*v1.ConfigMap)
+					if _, exists := configmap.Data["anapp"]; exists {
+						t.Fatal("Expected app anapp to be removed")
+					}
+					return true, nil, nil
+				})
+				return c.CoreV1().ConfigMaps("test")
+			},
+		},
+		{
+			Name:  "test remove app api key error",
+			AppID: "anapp",
+			Client: func(t *testing.T) corev1.ConfigMapInterface {
+				c := fake.Clientset{}
+				c.AddReactor("get", "configmaps", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New("not found")
+				})
+				return c.CoreV1().ConfigMaps("test")
+			},
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			appRepo := data.NewMobileAppRepo(tc.Client(t), data.DefaultMobileAppValidator{})
+			err := appRepo.RemoveAppAPIKeyByID(tc.AppID)
+			if tc.ExpectError && err == nil {
+				t.Fatal("expexted an error but got none")
+			}
+			if !tc.ExpectError && err != nil {
+				t.Fatalf("did not expect an err but got one %v", err)
+			}
+		})
+	}
+}
+
 func TestUpdateMobileApp(t *testing.T) {
 	cases := []struct {
 		Name        string

--- a/pkg/mobile/app/service.go
+++ b/pkg/mobile/app/service.go
@@ -36,3 +36,13 @@ func (s *Service) Create(appCrudder mobile.AppCruder, app *mobile.App) error {
 
 	return nil
 }
+
+func (s *Service) Delete(appCruder mobile.AppCruder, appID string) error {
+	if err := appCruder.DeleteByName(appID); err != nil {
+		return err
+	}
+	if err := appCruder.RemoveAppAPIKeyByID(appID); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/mobile/app/service_test.go
+++ b/pkg/mobile/app/service_test.go
@@ -1,6 +1,7 @@
 package app_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/feedhenry/mcp-standalone/pkg/mobile/app"
@@ -61,6 +62,59 @@ func TestCreateApp(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			service := &app.Service{}
 			err := service.Create(tc.AppCruder(), tc.MobileApp)
+			if tc.ExpectError && err == nil {
+				t.Fatalf("expected an err but got none!")
+			}
+			if !tc.ExpectError && err != nil {
+				t.Fatalf("did not expect and err but got one %v", err)
+			}
+		})
+	}
+}
+
+func TestRemoveAppByID(t *testing.T) {
+	cases := []struct {
+		Name        string
+		ExpectError bool
+		AppCruder   func() mobile.AppCruder
+		AppID       string
+	}{
+		{
+			Name: "test remove app ok",
+			AppCruder: func() mobile.AppCruder {
+				client := &fake.Clientset{}
+				client.AddReactor("get", "configmaps", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"group": "notmobile"},
+						},
+						Data: map[string]string{
+							"anapp": "anAppKey",
+						},
+					}, nil
+				})
+				return data.NewMobileAppRepo(client.CoreV1().ConfigMaps("test"), nil)
+			},
+			AppID: "anapp",
+		},
+		{
+			Name:        "test remove app error",
+			ExpectError: true,
+			AppCruder: func() mobile.AppCruder {
+				client := &fake.Clientset{}
+				client.AddReactor("get", "configmaps", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New("configmap doesn't exist")
+				})
+				return data.NewMobileAppRepo(client.CoreV1().ConfigMaps("test"), nil)
+			},
+			AppID: "anotherapp",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			service := &app.Service{}
+			err := service.Delete(tc.AppCruder(), tc.AppID)
 			if tc.ExpectError && err == nil {
 				t.Fatalf("expected an err but got none!")
 			}

--- a/pkg/mobile/interfaces.go
+++ b/pkg/mobile/interfaces.go
@@ -15,6 +15,7 @@ type AppCruder interface {
 	Update(app *App) (*App, error)
 	UpdateAppAPIKeys(app *App) error
 	CreateAppAPIKeyMap() error
+	RemoveAppAPIKeyByID(appID string) error
 }
 
 type ServiceCruder interface {

--- a/pkg/mock/mockClientBuilder.go
+++ b/pkg/mock/mockClientBuilder.go
@@ -68,3 +68,6 @@ func (mac *MockAppCruder) Update(app *mobile.App) (*mobile.App, error) {
 func (mac *MockAppCruder) CreateAppAPIKeyMap() error {
 	return mac.Err
 }
+func (mac *MockAppCruder) RemoveAppAPIKeyByID(appID string) error {
+	return mac.Err
+}

--- a/pkg/web/mobileappHandler.go
+++ b/pkg/web/mobileappHandler.go
@@ -86,11 +86,12 @@ func (m *MobileAppHandler) Delete(rw http.ResponseWriter, req *http.Request) {
 	}
 	params := mux.Vars(req)
 	id := params["id"]
-	if err := appRepo.DeleteByName(id); err != nil {
+
+	if err := m.appService.Delete(appRepo, id); err != nil {
+		err = errors.Wrap(err, "mobile app handler, failed to delete app")
 		handleCommonErrorCases(err, rw, m.logger)
 		return
 	}
-
 }
 
 // Create creates a mobileapp


### PR DESCRIPTION
@maleck13 Would you mind taking a look? This just deletes the keys from the configmap when an app is deleted