### PR TITLE
start removing the tokenclientbuilder

### DIFF
--- a/pkg/clients/tokenClientBuilder.go
+++ b/pkg/clients/tokenClientBuilder.go
@@ -14,7 +14,6 @@ import (
 // if there is token passed it will attempt to use the default sa token
 type TokenScopedClientBuilder struct {
 	clientBuilder      mobile.ClientBuilder
-	appRepoBuilder     mobile.AppRepoBuilder
 	serviceRepoBuilder mobile.ServiceRepoBuilder
 	namespace          string
 	logger             *logrus.Logger
@@ -25,10 +24,9 @@ type TokenScopedClientBuilder struct {
 }
 
 // NewTokenScopedClientBuilder returns a new client builder that builds clients using the token provided
-func NewTokenScopedClientBuilder(cb mobile.ClientBuilder, arb mobile.AppRepoBuilder, srv mobile.ServiceRepoBuilder, mb mobile.MounterBuilder, namespace string, logger *logrus.Logger) *TokenScopedClientBuilder {
+func NewTokenScopedClientBuilder(cb mobile.ClientBuilder, srv mobile.ServiceRepoBuilder, mb mobile.MounterBuilder, namespace string, logger *logrus.Logger) *TokenScopedClientBuilder {
 	return &TokenScopedClientBuilder{
 		clientBuilder:      cb,
-		appRepoBuilder:     arb,
 		serviceRepoBuilder: srv,
 		namespace:          namespace,
 		logger:             logger,
@@ -49,16 +47,6 @@ func (rsb *TokenScopedClientBuilder) UseDefaultSAToken() mobile.TokenScopedClien
 	var cloned = *rsb
 	cloned.useSaToken = true
 	return &cloned
-}
-
-// MobileAppCruder returns a token scoped MobileAppCruder
-func (rsb *TokenScopedClientBuilder) MobileAppCruder(token string) (mobile.AppCruder, error) {
-	token = rsb.token(token)
-	k8s, err := rsb.K8s(token)
-	if err != nil {
-		return nil, err
-	}
-	return rsb.appRepoBuilder.WithClient(k8s.CoreV1().ConfigMaps(rsb.namespace)).Build(), nil
 }
 
 // K8s will build a token scoped kuberentes client

--- a/pkg/mobile/interfaces.go
+++ b/pkg/mobile/interfaces.go
@@ -41,10 +41,11 @@ type ClientBuilder interface {
 	BuildClient() (kubernetes.Interface, error)
 }
 
-// TODO prob can remote the WithClient and instead use NewRepoBuilder(c corev1.ConfigMapInterface) and have this just expose Build() and perhaps add WithToken(token string)
 type AppRepoBuilder interface {
-	WithClient(c corev1.ConfigMapInterface) AppRepoBuilder
-	Build() AppCruder
+	WithToken(token string) AppRepoBuilder
+	//UseDefaultSAToken delegates off to the service account token setup with the MCP. This should only be used for APIs where no real token is provided and should always be protected
+	UseDefaultSAToken() AppRepoBuilder
+	Build() (AppCruder, error)
 }
 
 // TODO prob can remote the WithClient and instead use NewRepoBuilder(c corev1.ConfigMapInterface) and have this just expose Build() and perhaps add WithToken(token string)
@@ -55,7 +56,6 @@ type ServiceRepoBuilder interface {
 
 type TokenScopedClientBuilder interface {
 	K8s(token string) (kubernetes.Interface, error)
-	MobileAppCruder(token string) (AppCruder, error)
 	MobileServiceCruder(token string) (ServiceCruder, error)
 	UseDefaultSAToken() TokenScopedClientBuilder
 	VolumeMounterUnmounter(token string) (VolumeMounterUnmounter, error)

--- a/pkg/mobile/metrics/keycloak_test.go
+++ b/pkg/mobile/metrics/keycloak_test.go
@@ -29,12 +29,10 @@ func buildDefaultTestTokenClientBuilder(kclient kubernetes.Interface) mobile.Tok
 	cb := &mock.ClientBuilder{
 		Fakeclient: kclient,
 	}
-	appRepoBuilder := data.NewMobileAppRepoBuilder()
-	appRepoBuilder = appRepoBuilder.WithClient(kclient.CoreV1().ConfigMaps("test"))
 	svcRepoBuilder := data.NewServiceRepoBuilder()
 	svcRepoBuilder = svcRepoBuilder.WithClient(kclient.CoreV1().Secrets("test"))
 	mounterBuilder := k8s.NewMounterBuilder("test")
-	clientBuilder := clients.NewTokenScopedClientBuilder(cb, appRepoBuilder, svcRepoBuilder, mounterBuilder, "test", logger)
+	clientBuilder := clients.NewTokenScopedClientBuilder(cb, svcRepoBuilder, mounterBuilder, "test", logger)
 	return clientBuilder
 }
 

--- a/pkg/mock/mockClientBuilder.go
+++ b/pkg/mock/mockClientBuilder.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"github.com/feedhenry/mcp-standalone/pkg/mobile"
 	"k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 type ClientBuilder struct {
@@ -28,43 +27,4 @@ func (cb *ClientBuilder) WithHostAndNamespace(host, ns string) mobile.ClientBuil
 func (cb *ClientBuilder) BuildClient() (kubernetes.Interface, error) {
 	return cb.Fakeclient, nil
 
-}
-
-type AppRepoBuilder struct {
-	AppCruder *MockAppCruder
-}
-
-func (arb *AppRepoBuilder) WithClient(c corev1.ConfigMapInterface) mobile.AppRepoBuilder {
-	return &AppRepoBuilder{AppCruder: arb.AppCruder}
-}
-func (arb *AppRepoBuilder) Build() mobile.AppCruder {
-	return arb.AppCruder
-}
-
-type MockAppCruder struct {
-	App  *mobile.App
-	Apps []*mobile.App
-	Err  error
-}
-
-func (mac *MockAppCruder) UpdateAppAPIKeys(app *mobile.App) error {
-	return mac.Err
-}
-func (mac *MockAppCruder) ReadByName(name string) (*mobile.App, error) {
-	return mac.App, mac.Err
-}
-func (mac *MockAppCruder) Create(app *mobile.App) error {
-	return mac.Err
-}
-func (mac *MockAppCruder) DeleteByName(name string) error {
-	return mac.Err
-}
-func (mac *MockAppCruder) List() ([]*mobile.App, error) {
-	return mac.Apps, mac.Err
-}
-func (mac *MockAppCruder) Update(app *mobile.App) (*mobile.App, error) {
-	return mac.App, mac.Err
-}
-func (mac *MockAppCruder) CreateAppAPIKeyMap() error {
-	return mac.Err
 }

--- a/pkg/web/SDKConfigHandler.go
+++ b/pkg/web/SDKConfigHandler.go
@@ -15,15 +15,17 @@ import (
 type SDKConfigHandler struct {
 	mobileIntegrationService *integration.SDKService
 	tokenScopedBuilder       mobile.TokenScopedClientBuilder
+	appRepoBuilder           mobile.AppRepoBuilder
 	logger                   *logrus.Logger
 }
 
 // NewSDKConfigHandler returns an sdk handler
-func NewSDKConfigHandler(logger *logrus.Logger, service *integration.SDKService, builder mobile.TokenScopedClientBuilder) *SDKConfigHandler {
+func NewSDKConfigHandler(logger *logrus.Logger, service *integration.SDKService, builder mobile.TokenScopedClientBuilder, repoBuilder mobile.AppRepoBuilder) *SDKConfigHandler {
 	return &SDKConfigHandler{
 		mobileIntegrationService: service,
 		logger:             logger,
 		tokenScopedBuilder: builder,
+		appRepoBuilder:     repoBuilder,
 	}
 }
 
@@ -37,7 +39,7 @@ func (sdk *SDKConfigHandler) Read(rw http.ResponseWriter, req *http.Request) {
 	}
 	//TODO maybe bring this  apiKey check out of this handler
 	//need to use the serviceaccount token here to read and check the app key and svcs
-	appCruder, err := sdk.tokenScopedBuilder.UseDefaultSAToken().MobileAppCruder("")
+	appCruder, err := sdk.appRepoBuilder.UseDefaultSAToken().Build()
 	if err != nil {
 		err = errors.Wrap(err, "failed to setup mobile app cruder using sa token")
 		handleCommonErrorCases(err, rw, sdk.logger)

--- a/pkg/web/SDKConfigHandler_test.go
+++ b/pkg/web/SDKConfigHandler_test.go
@@ -12,8 +12,10 @@ import (
 	v1 "k8s.io/client-go/pkg/api/v1"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/feedhenry/mcp-standalone/pkg/data"
 	"github.com/feedhenry/mcp-standalone/pkg/mobile"
 	"github.com/feedhenry/mcp-standalone/pkg/mobile/integration"
+	"github.com/feedhenry/mcp-standalone/pkg/mock"
 	"github.com/feedhenry/mcp-standalone/pkg/web"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -24,8 +26,12 @@ func setupSDKHandler(kclient kubernetes.Interface) http.Handler {
 	r := web.NewRouter()
 	logger := logrus.StandardLogger()
 	clientBuilder := buildDefaultTestTokenClientBuilder(kclient)
+	cb := &mock.ClientBuilder{
+		Fakeclient: kclient,
+	}
+	appRepoBuilder := data.NewMobileAppRepoBuilder(cb, "test", "test")
 	ms := &integration.SDKService{}
-	sdkConfigHandler := web.NewSDKConfigHandler(logger, ms, clientBuilder)
+	sdkConfigHandler := web.NewSDKConfigHandler(logger, ms, clientBuilder, appRepoBuilder)
 	web.SDKConfigRoute(r, sdkConfigHandler)
 	return web.BuildHTTPHandler(r, nil)
 }

--- a/pkg/web/mobileServicesHandler_test.go
+++ b/pkg/web/mobileServicesHandler_test.go
@@ -48,12 +48,10 @@ func buildDefaultTestTokenClientBuilder(kclient kubernetes.Interface) mobile.Tok
 	cb := &mock.ClientBuilder{
 		Fakeclient: kclient,
 	}
-	appRepoBuilder := data.NewMobileAppRepoBuilder()
-	appRepoBuilder = appRepoBuilder.WithClient(kclient.CoreV1().ConfigMaps("test"))
 	svcRepoBuilder := data.NewServiceRepoBuilder()
 	svcRepoBuilder = svcRepoBuilder.WithClient(kclient.CoreV1().Secrets("test"))
 	mounterBuilder := k8s.NewMounterBuilder("test")
-	clientBuilder := clients.NewTokenScopedClientBuilder(cb, appRepoBuilder, svcRepoBuilder, mounterBuilder, "test", logger)
+	clientBuilder := clients.NewTokenScopedClientBuilder(cb, svcRepoBuilder, mounterBuilder, "test", logger)
 	return clientBuilder
 }
 

--- a/pkg/web/mobileappHandler.go
+++ b/pkg/web/mobileappHandler.go
@@ -14,17 +14,17 @@ import (
 
 // MobileAppHandler handle mobile actions
 type MobileAppHandler struct {
-	logger             *logrus.Logger
-	tokenClientBuilder mobile.TokenScopedClientBuilder
-	appService         *app.Service
+	logger           *logrus.Logger
+	appService       *app.Service
+	appCruderBuilder mobile.AppRepoBuilder
 }
 
 // NewMobileAppHandler returns a new mobile app handler
-func NewMobileAppHandler(logger *logrus.Logger, tokenClientBuilder mobile.TokenScopedClientBuilder, appService *app.Service) *MobileAppHandler {
+func NewMobileAppHandler(logger *logrus.Logger, app mobile.AppRepoBuilder, appService *app.Service) *MobileAppHandler {
 	return &MobileAppHandler{
-		logger:             logger,
-		tokenClientBuilder: tokenClientBuilder,
-		appService:         appService,
+		logger:           logger,
+		appCruderBuilder: app,
+		appService:       appService,
 	}
 }
 
@@ -32,7 +32,7 @@ func NewMobileAppHandler(logger *logrus.Logger, tokenClientBuilder mobile.TokenS
 func (m *MobileAppHandler) Read(rw http.ResponseWriter, req *http.Request) {
 	// we return the actul request handleing function now that it has been configured.
 	token := headers.DefaultTokenRetriever(req.Header)
-	appRepo, err := m.tokenClientBuilder.MobileAppCruder(token)
+	appRepo, err := m.appCruderBuilder.WithToken(token).Build()
 	if err != nil {
 		handleCommonErrorCases(err, rw, m.logger)
 		return
@@ -58,7 +58,7 @@ func (m *MobileAppHandler) Read(rw http.ResponseWriter, req *http.Request) {
 // List will list mobile apps
 func (m *MobileAppHandler) List(rw http.ResponseWriter, req *http.Request) {
 	token := headers.DefaultTokenRetriever(req.Header)
-	appRepo, err := m.tokenClientBuilder.MobileAppCruder(token)
+	appRepo, err := m.appCruderBuilder.WithToken(token).Build()
 	if err != nil {
 		handleCommonErrorCases(err, rw, m.logger)
 		return
@@ -79,7 +79,7 @@ func (m *MobileAppHandler) List(rw http.ResponseWriter, req *http.Request) {
 // Delete will delete a mobile app
 func (m *MobileAppHandler) Delete(rw http.ResponseWriter, req *http.Request) {
 	token := headers.DefaultTokenRetriever(req.Header)
-	appRepo, err := m.tokenClientBuilder.MobileAppCruder(token)
+	appRepo, err := m.appCruderBuilder.WithToken(token).Build()
 	if err != nil {
 		handleCommonErrorCases(err, rw, m.logger)
 		return
@@ -96,7 +96,7 @@ func (m *MobileAppHandler) Delete(rw http.ResponseWriter, req *http.Request) {
 // Create creates a mobileapp
 func (m *MobileAppHandler) Create(rw http.ResponseWriter, req *http.Request) {
 	token := headers.DefaultTokenRetriever(req.Header)
-	appRepo, err := m.tokenClientBuilder.MobileAppCruder(token)
+	appRepo, err := m.appCruderBuilder.WithToken(token).Build()
 	if err != nil {
 		handleCommonErrorCases(err, rw, m.logger)
 		return

--- a/pkg/web/mobileappHandler_test.go
+++ b/pkg/web/mobileappHandler_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/feedhenry/mcp-standalone/pkg/data"
 	"github.com/feedhenry/mcp-standalone/pkg/mobile"
 	"github.com/feedhenry/mcp-standalone/pkg/mobile/app"
+	"github.com/feedhenry/mcp-standalone/pkg/mock"
 	"github.com/feedhenry/mcp-standalone/pkg/web"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,9 +25,12 @@ import (
 func setupMobileAppHandler(kclient kubernetes.Interface) http.Handler {
 	r := web.NewRouter()
 	logger := logrus.StandardLogger()
-	clientBuilder := buildDefaultTestTokenClientBuilder(kclient)
+	cb := &mock.ClientBuilder{
+		Fakeclient: kclient,
+	}
+	appRepoBuilder := data.NewMobileAppRepoBuilder(cb, "test", "test")
 	appService := &app.Service{}
-	handler := web.NewMobileAppHandler(logger, clientBuilder, appService)
+	handler := web.NewMobileAppHandler(logger, appRepoBuilder, appService)
 	web.MobileAppRoute(r, handler)
 	return web.BuildHTTPHandler(r, nil)
 }


### PR DESCRIPTION
@philbrookes this is the first of a few PRs. removes the AppRepoBuilder from the token client builder and updates all tests and deps