### PR TITLE
Fixing incorrect license header

### DIFF
--- a/artifacts/Dockerfile
+++ b/artifacts/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 The Kubernetes Authors.
+# Copyright 2017 Red Hat, Inc, and individual contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is what license headers normally look like in RHT 