### PR TITLE
WIP Fh 4128 create build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ run_server:
 	oc create -f install/openshift/sa.local.json -n  $(NAMESPACE) | true
 	oc policy add-role-to-user edit system:serviceaccount:$(NAMESPACE):mcp-standalone -n  $(NAMESPACE) | true
 	oc sa get-token mcp-standalone -n  $(NAMESPACE) > token
-	./mcp-api -namespace=$(NAMESPACE) -k8-host=$(OSCP) -satoken-path=./token -log-level=debug
+	./mcp-api -namespace=$(NAMESPACE) -k8-host=$(OSCP) -satoken-path=./token -log-level=debug -insecure=true
 
 
 test: test-unit

--- a/pkg/cli/cmd/mobileapp.go
+++ b/pkg/cli/cmd/mobileapp.go
@@ -51,7 +51,6 @@ var getmobileappCmd = &cobra.Command{
 		if name != "" {
 			u.Path = path.Join(u.Path, "/"+name)
 		}
-		fmt.Println(u.String())
 		req, err := http.NewRequest("GET", u.String(), nil)
 		if err != nil {
 			log.Fatalf(" %s : failed to create new get request %s ", cmd.Name(), err)

--- a/pkg/data/mobileApp.go
+++ b/pkg/data/mobileApp.go
@@ -241,7 +241,7 @@ func (mar *MobileAppRepo) readUnderlyingConfigMap(a *mobile.App) (*v1.ConfigMap,
 }
 
 //NewMobileAppRepoBuilder creates a new instance of a MobileAppRepoBuilder
-func NewMobileAppRepoBuilder(clientBuilder mobile.ClientBuilder, namespace, saToken string) mobile.AppRepoBuilder {
+func NewMobileAppRepoBuilder(clientBuilder mobile.K8ClientBuilder, namespace, saToken string) mobile.AppRepoBuilder {
 	return &MobileAppRepoBuilder{
 		clientBuilder: clientBuilder,
 		namespace:     namespace,
@@ -251,7 +251,7 @@ func NewMobileAppRepoBuilder(clientBuilder mobile.ClientBuilder, namespace, saTo
 
 // MobileAppRepoBuilder builds a MobileAppRepo
 type MobileAppRepoBuilder struct {
-	clientBuilder mobile.ClientBuilder
+	clientBuilder mobile.K8ClientBuilder
 	token         string
 	namespace     string
 	saToken       string

--- a/pkg/data/mobileBuilds.go
+++ b/pkg/data/mobileBuilds.go
@@ -1,0 +1,152 @@
+package data
+
+import (
+	"fmt"
+
+	"github.com/feedhenry/mcp-standalone/pkg/mobile"
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/build"
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/client"
+	"github.com/pkg/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/pkg/api/v1"
+	kapi "k8s.io/client-go/pkg/api/v1"
+)
+
+type BuildRepo struct {
+	buildClient  client.BuildConfigInterface
+	secretClient corev1.SecretInterface
+	validator    MobileBuildValidator
+}
+
+func NewBuildRepo(bc client.BuildConfigInterface, sc corev1.SecretInterface) *BuildRepo {
+	return &BuildRepo{
+		buildClient:  bc,
+		secretClient: sc,
+	}
+}
+
+func (br *BuildRepo) Create(b *mobile.Build) error {
+	bc := convertMobileBuildToBuildConfig(b)
+	if _, err := br.buildClient.Create(bc); err != nil {
+		return errors.Wrap(err, "build repo failed to create underlying buildconfig")
+	}
+	return nil
+}
+
+// AddBuildAsset will create a secret and return its name
+func (br *BuildRepo) AddBuildAsset(b *mobile.Build, assetName string, keyValues map[string][]byte) (string, error) {
+	secret := &v1.Secret{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Labels: map[string]string{"mobile-appid": b.AppID, "buildID": b.Name},
+			Name:   assetName,
+		},
+		Data: keyValues,
+	}
+	s, err := br.secretClient.Create(secret)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to add build asset")
+	}
+	return s.Name, nil
+
+}
+
+func (br *BuildRepo) Update(config *build.BuildConfig) (*build.BuildConfig, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+func convertMobileBuildToBuildConfig(b *mobile.Build) *build.BuildConfig {
+	bc := &build.BuildConfig{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Labels: map[string]string{"mobile-appid": b.AppID},
+			Name:   b.Name,
+		},
+		Spec: build.BuildConfigSpec{
+			CommonSpec: build.CommonSpec{
+				Strategy: build.BuildStrategy{
+					Type: build.JenkinsPipelineBuildStrategyType,
+					JenkinsPipelineStrategy: &build.JenkinsPipelineBuildStrategy{
+						JenkinsfilePath: "Jenkinsfile",
+					},
+				},
+				Source: build.BuildSource{
+					Git: &build.GitBuildSource{
+
+						URI: b.GitRepo.URI,
+						Ref: b.GitRepo.Ref,
+					},
+				},
+			},
+		},
+	}
+
+	if b.GitRepo.Private {
+		bc.Spec.Source.SourceSecret = &kapi.LocalObjectReference{
+			Name: b.GitRepo.PublicKeyID,
+		}
+	}
+	return bc
+}
+
+func convertBuildConfigToMobileBuild(b *build.BuildConfig) (*mobile.Build, error) {
+	return nil, nil
+}
+
+// MobileBuildValidator defines what a validator should do
+type MobileBuildValidator interface {
+	PreCreate(a *mobile.Build) error
+	PreUpdate(old *mobile.Build, new *mobile.Build) error
+}
+
+// NewBuildsRepoBuilder provides an implementation of mobile.ServiceRepoBuilder
+func NewBuildsRepoBuilder(clientBuilder mobile.K8ClientBuilder, ocClientBuilder mobile.OSClientBuilder, namespace, saToken string) mobile.BuildRepoBuilder {
+	return &BuildRepoBuilder{
+		clientBuilder:   clientBuilder,
+		ocClientBuilder: ocClientBuilder,
+		saToken:         saToken,
+		namespace:       namespace,
+	}
+}
+
+type BuildRepoBuilder struct {
+	clientBuilder   mobile.K8ClientBuilder
+	ocClientBuilder mobile.OSClientBuilder
+	token           string
+	namespace       string
+	saToken         string
+}
+
+func (marb *BuildRepoBuilder) WithToken(token string) mobile.BuildRepoBuilder {
+	return &BuildRepoBuilder{
+		clientBuilder:   marb.clientBuilder,
+		ocClientBuilder: marb.ocClientBuilder,
+		token:           token,
+		saToken:         marb.saToken,
+		namespace:       marb.namespace,
+	}
+}
+
+//UseDefaultSAToken delegates off to the service account token setup with the MCP. This should only be used for APIs where no real token is provided and should always be protected
+func (marb *BuildRepoBuilder) UseDefaultSAToken() mobile.BuildRepoBuilder {
+	return &BuildRepoBuilder{
+		clientBuilder:   marb.clientBuilder,
+		ocClientBuilder: marb.ocClientBuilder,
+		token:           marb.saToken,
+		saToken:         marb.saToken,
+		namespace:       marb.namespace,
+	}
+
+}
+
+// Build builds the final repo
+func (marb *BuildRepoBuilder) Build() (mobile.BuildCruder, error) {
+	k8client, err := marb.clientBuilder.WithToken(marb.token).BuildClient()
+	if err != nil {
+		return nil, errors.Wrap(err, "MobileAppRepoBuilder failed to build a configmap client")
+	}
+	ocClient, err := marb.ocClientBuilder.WithToken(marb.token).BuildClient()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build ocClient ")
+	}
+	return NewBuildRepo(ocClient.BuildConfigs(marb.namespace), k8client.CoreV1().Secrets(marb.namespace)), nil
+}

--- a/pkg/data/mobileBuilds_test.go
+++ b/pkg/data/mobileBuilds_test.go
@@ -1,0 +1,88 @@
+package data_test
+
+import (
+	"testing"
+
+	"errors"
+
+	"github.com/feedhenry/mcp-standalone/pkg/data"
+	"github.com/feedhenry/mcp-standalone/pkg/mobile"
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/client"
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/testclient"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestBuildRepo_Create(t *testing.T) {
+	cases := []struct {
+		Name         string
+		ExpectError  bool
+		BuildClient  func() client.BuildConfigInterface
+		SecretClient func() corev1.SecretInterface
+		Build        *mobile.Build
+	}{
+		{
+			"test creating build succeeds",
+			false,
+			func() client.BuildConfigInterface {
+				fakeoc := testclient.NewFakeBuildConfigs("test", nil)
+				fakeoc.Fake.AddReactor("create", "buildconfigs", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, nil
+				})
+				return fakeoc
+			},
+			func() corev1.SecretInterface {
+				kc := &fake.Clientset{}
+				return kc.CoreV1().Secrets("test")
+			},
+			&mobile.Build{
+				Name:  "test",
+				AppID: "test",
+				GitRepo: &mobile.BuildGitRepo{
+					Private: true,
+					URI:     "git@git.com",
+					Ref:     "master",
+				},
+			},
+		},
+		{
+			"test creating build fails when buildconfig not created",
+			true,
+			func() client.BuildConfigInterface {
+				fakeoc := testclient.NewFakeBuildConfigs("test", nil)
+				fakeoc.Fake.AddReactor("create", "buildconfigs", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New("failed to create")
+				})
+				return fakeoc
+			},
+			func() corev1.SecretInterface {
+				kc := &fake.Clientset{}
+				return kc.CoreV1().Secrets("test")
+			},
+			&mobile.Build{
+				Name:  "test",
+				AppID: "test",
+				GitRepo: &mobile.BuildGitRepo{
+					Private: true,
+					URI:     "git@git.com",
+					Ref:     "master",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			buildRepo := data.NewBuildRepo(tc.BuildClient(), tc.SecretClient())
+			err := buildRepo.Create(tc.Build)
+			if tc.ExpectError && err == nil {
+				t.Fatalf("expected an error but got none")
+			}
+			if !tc.ExpectError && err != nil {
+				t.Fatalf("did not expect error but got %s ", err)
+			}
+		})
+	}
+}

--- a/pkg/data/mobileBuilds_test.go
+++ b/pkg/data/mobileBuilds_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/pkg/api/v1"
 	ktesting "k8s.io/client-go/testing"
 )
 
@@ -82,6 +83,78 @@ func TestBuildRepo_Create(t *testing.T) {
 			}
 			if !tc.ExpectError && err != nil {
 				t.Fatalf("did not expect error but got %s ", err)
+			}
+		})
+	}
+}
+
+func TestBuildRepo_AddBuildAsset(t *testing.T) {
+	cases := []struct {
+		Name         string
+		ExpectError  bool
+		SecretClient func() corev1.SecretInterface
+		BuildAsset   mobile.BuildAsset
+	}{
+		{
+			Name: "test adding source credential asset ok",
+			SecretClient: func() corev1.SecretInterface {
+				kc := &fake.Clientset{}
+				kc.AddReactor("create", "secrets", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					secret := action.(ktesting.CreateAction).GetObject().(*v1.Secret)
+					if _, ok := secret.Labels["type"]; !ok || secret.Labels["type"] != string(mobile.BuildAssetTypeSourceCredential) {
+						t.Fatalf("expected the sercret to have a lable with a type %s, %v", mobile.BuildAssetTypeSourceCredential, secret.Labels)
+					}
+					if _, ok := secret.Data["key"]; !ok {
+						t.Fatalf("expected the secret to have data under with key:   key but it was missing %v", secret.Data)
+					}
+					return true, secret, nil
+				})
+				return kc.CoreV1().Secrets("test")
+			},
+			BuildAsset: mobile.BuildAsset{
+				Name:    "myapp",
+				AppName: "myapp",
+				AssetData: map[string][]byte{
+					"key": []byte("sdasdsadsadsa"),
+				},
+				Type:      mobile.BuildAssetTypeSourceCredential,
+				BuildName: "mybuild",
+			},
+		},
+		{
+			Name: "test adding source credential fails when secret creation fails",
+			SecretClient: func() corev1.SecretInterface {
+				kc := &fake.Clientset{}
+				kc.AddReactor("create", "secrets", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New("failed to create secret")
+				})
+				return kc.CoreV1().Secrets("test")
+			},
+			BuildAsset: mobile.BuildAsset{
+				Name:    "myapp",
+				AppName: "myapp",
+				AssetData: map[string][]byte{
+					"key": []byte("sdasdsadsadsa"),
+				},
+				Type:      mobile.BuildAssetTypeSourceCredential,
+				BuildName: "mybuild",
+			},
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			buildRepo := data.NewBuildRepo(nil, tc.SecretClient())
+			secretName, err := buildRepo.AddBuildAsset(tc.BuildAsset)
+			if tc.ExpectError && err == nil {
+				t.Fatalf("expected an error but got none")
+			}
+			if !tc.ExpectError && err != nil {
+				t.Fatalf("did not expect error but got %s ", err)
+			}
+			if !tc.ExpectError && secretName == "" {
+				t.Fatal("expected a secret name to be returned but got none")
 			}
 		})
 	}

--- a/pkg/data/mobileService.go
+++ b/pkg/data/mobileService.go
@@ -242,7 +242,7 @@ func convertSecretToMobileService(s v1.Secret) *mobile.Service {
 }
 
 // NewServiceRepoBuilder provides an implementation of mobile.ServiceRepoBuilder
-func NewServiceRepoBuilder(clientBuilder mobile.ClientBuilder, namespace, saToken string) mobile.ServiceRepoBuilder {
+func NewServiceRepoBuilder(clientBuilder mobile.K8ClientBuilder, namespace, saToken string) mobile.ServiceRepoBuilder {
 	return &MobileServiceRepoBuilder{
 		clientBuilder: clientBuilder,
 		saToken:       saToken,
@@ -252,7 +252,7 @@ func NewServiceRepoBuilder(clientBuilder mobile.ClientBuilder, namespace, saToke
 
 // MobileServiceRepoBuilder builds a ServiceCruder
 type MobileServiceRepoBuilder struct {
-	clientBuilder mobile.ClientBuilder
+	clientBuilder mobile.K8ClientBuilder
 	token         string
 	namespace     string
 	saToken       string

--- a/pkg/data/mobileValidator.go
+++ b/pkg/data/mobileValidator.go
@@ -42,6 +42,7 @@ func validateClientType(a *mobile.App) error {
 
 type DefaultMobileServiceValidator struct{}
 
+//TODO fill these out
 func (msv DefaultMobileServiceValidator) PreCreate(ms *mobile.Service) error {
 	return nil
 }

--- a/pkg/data/mobileValidator.go
+++ b/pkg/data/mobileValidator.go
@@ -50,3 +50,14 @@ func (msv DefaultMobileServiceValidator) PreCreate(ms *mobile.Service) error {
 func (msv DefaultMobileServiceValidator) PreUpdate(old *mobile.Service, new *mobile.Service) error {
 	return nil
 }
+
+type DefaultMobileBuildValidator struct{}
+
+//TODO fill these out
+func (msv DefaultMobileBuildValidator) PreCreate(mb *mobile.Build) error {
+	return nil
+}
+
+func (msv DefaultMobileBuildValidator) PreUpdate(old *mobile.Build, new *mobile.Build) error {
+	return nil
+}

--- a/pkg/k8s/clientBuilder.go
+++ b/pkg/k8s/clientBuilder.go
@@ -14,14 +14,15 @@ type ClientBuilder struct {
 	inCluster              bool
 }
 
-func NewClientBuilder(namespace, host string) mobile.ClientBuilder {
+func NewClientBuilder(namespace, host string, incluster bool) mobile.K8ClientBuilder {
 	return &ClientBuilder{
 		namespace: namespace,
 		host:      host,
+		inCluster: incluster,
 	}
 }
 
-func (cb *ClientBuilder) WithToken(token string) mobile.ClientBuilder {
+func (cb *ClientBuilder) WithToken(token string) mobile.K8ClientBuilder {
 	//important to return a new instance
 	return &ClientBuilder{
 		namespace: cb.namespace,
@@ -30,14 +31,14 @@ func (cb *ClientBuilder) WithToken(token string) mobile.ClientBuilder {
 	}
 }
 
-func (cb *ClientBuilder) WithNamespace(ns string) mobile.ClientBuilder {
+func (cb *ClientBuilder) WithNamespace(ns string) mobile.K8ClientBuilder {
 	return &ClientBuilder{
 		namespace: ns,
 		token:     cb.token,
 		host:      cb.host,
 	}
 }
-func (cb *ClientBuilder) WithHost(host string) mobile.ClientBuilder {
+func (cb *ClientBuilder) WithHost(host string) mobile.K8ClientBuilder {
 	return &ClientBuilder{
 		namespace: cb.namespace,
 		token:     cb.token,
@@ -45,7 +46,7 @@ func (cb *ClientBuilder) WithHost(host string) mobile.ClientBuilder {
 	}
 }
 
-func (cb *ClientBuilder) WithHostAndNamespace(host, ns string) mobile.ClientBuilder {
+func (cb *ClientBuilder) WithHostAndNamespace(host, ns string) mobile.K8ClientBuilder {
 	return &ClientBuilder{
 		namespace: ns,
 		token:     cb.token,

--- a/pkg/k8s/mounterBuilder.go
+++ b/pkg/k8s/mounterBuilder.go
@@ -13,11 +13,11 @@ type MounterBuilder struct {
 	namespace     string
 	saToken       string
 	token         string
-	clientBuilder mobile.ClientBuilder
+	clientBuilder mobile.K8ClientBuilder
 }
 
 // NewMounterBuilder creates a new MounterBuilder in the provided namespace
-func NewMounterBuilder(clientBuilder mobile.ClientBuilder, namespace, saToken string) mobile.MounterBuilder {
+func NewMounterBuilder(clientBuilder mobile.K8ClientBuilder, namespace, saToken string) mobile.MounterBuilder {
 	return &MounterBuilder{
 		namespace:     namespace,
 		clientBuilder: clientBuilder,

--- a/pkg/mobile/app/builds.go
+++ b/pkg/mobile/app/builds.go
@@ -1,0 +1,81 @@
+package app
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+
+	"encoding/asn1"
+
+	"github.com/feedhenry/mcp-standalone/pkg/mobile"
+	"github.com/pkg/errors"
+)
+
+type Build struct {
+}
+
+func NewBuild() *Build {
+	return &Build{}
+}
+
+type AppBuildCreatedResponse struct {
+	PublicKey string `json:"publicKey"`
+	BuildID   string `json:buildID`
+}
+
+func (b *Build) CreateAppBuild(buildRepo mobile.BuildCruder, build *mobile.Build) (*AppBuildCreatedResponse, error) {
+	var res = &AppBuildCreatedResponse{BuildID: build.Name}
+	if !build.GitRepo.Private {
+		if err := buildRepo.Create(build); err != nil {
+			return nil, errors.Wrap(err, "CreateAppBuild: failed to create build")
+		}
+		return res, nil
+	}
+	//setup pki
+	var (
+		privateKeyVal *bytes.Buffer
+		publicKeyVal  *bytes.Buffer
+		reader        = rand.Reader
+		bitSize       = 2048
+	)
+	key, err := rsa.GenerateKey(reader, bitSize)
+	if err != nil {
+		return nil, errors.Wrap(err, "CreateAppBuild: failed to generate a new rsa key pair when creating new app build")
+	}
+	var privateKey = &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	privateKeyVal = &bytes.Buffer{}
+	err = pem.Encode(privateKeyVal, privateKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "CreateAppBuild: failed to encode private key for new app build ")
+	}
+	pKey, err := asn1.Marshal(key.PublicKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "CreateAppBuild: failed to marshal public key when creating app build")
+	}
+	var pubkey = &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pKey,
+	}
+	publicKeyVal = &bytes.Buffer{}
+	if err = pem.Encode(publicKeyVal, pubkey); err != nil {
+		return nil, errors.Wrap(err, "CreateAppBuild: failed to encode public key for new app build")
+	}
+	build.GitRepo.PublicKey = publicKeyVal.String()
+	res.PublicKey = publicKeyVal.String()
+	asset, err := buildRepo.AddBuildAsset(build, build.Name+"ssh-key", map[string][]byte{"ssh-privatekey": privateKeyVal.Bytes()})
+	if err != nil {
+		return nil, errors.Wrap(err, "CreateAppBuild: failed to add build asset ssh-key ")
+	}
+	build.GitRepo.PublicKeyID = asset
+	if err := buildRepo.Create(build); err != nil {
+		return nil, errors.Wrap(err, "CreateAppBuild: failed to create build")
+	}
+	return res, nil
+
+}

--- a/pkg/mobile/app/builds_test.go
+++ b/pkg/mobile/app/builds_test.go
@@ -1,0 +1,101 @@
+package app_test
+
+import (
+	"testing"
+
+	"strings"
+
+	"github.com/feedhenry/mcp-standalone/pkg/data"
+	"github.com/feedhenry/mcp-standalone/pkg/mobile"
+	"github.com/feedhenry/mcp-standalone/pkg/mobile/app"
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/client"
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/testclient"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func TestBuild_CreateAppBuild(t *testing.T) {
+	cases := []struct {
+		Name         string
+		Build        *mobile.Build
+		ExpectError  bool
+		BuildClient  func() client.BuildConfigInterface
+		SecretClient func() corev1.SecretInterface
+		Validate     func(t *testing.T, br *app.AppBuildCreatedResponse)
+	}{
+		{
+			Name: "test create app build with new public private key",
+			Build: &mobile.Build{
+				AppID: "test",
+				Name:  "test",
+				GitRepo: &mobile.BuildGitRepo{
+					URI:     "git@git.com",
+					Private: true,
+				},
+			},
+			BuildClient: func() client.BuildConfigInterface {
+				fakeoc := testclient.NewFakeBuildConfigs("test", nil)
+				return fakeoc
+			},
+			SecretClient: func() corev1.SecretInterface {
+				fakec := &fake.Clientset{}
+				return fakec.CoreV1().Secrets("test")
+			},
+			Validate: func(t *testing.T, br *app.AppBuildCreatedResponse) {
+				if nil == br {
+					t.Fatal("expected an app build response but got nil")
+				}
+				if br.PublicKey == "" {
+					t.Fatal("expected a public key but it was empty")
+				}
+				if !strings.Contains(br.PublicKey, "PUBLIC KEY") {
+					t.Fatal("expected a public key but did not find public key comment ", br.PublicKey)
+				}
+			},
+		},
+		{
+			Name: "test create app build with no public private key",
+			Build: &mobile.Build{
+				AppID: "test",
+				Name:  "test",
+				GitRepo: &mobile.BuildGitRepo{
+					URI:     "git@git.com",
+					Private: false,
+				},
+			},
+			BuildClient: func() client.BuildConfigInterface {
+				fakeoc := testclient.NewFakeBuildConfigs("test", nil)
+				return fakeoc
+			},
+			SecretClient: func() corev1.SecretInterface {
+				fakes := &fake.Clientset{}
+				return fakes.CoreV1().Secrets("test")
+			},
+			Validate: func(t *testing.T, br *app.AppBuildCreatedResponse) {
+				if nil == br {
+					t.Fatal("expected an app build response but got nil")
+				}
+				if br.PublicKey != "" {
+					t.Fatalf("did not expect a public key but found %s ", br.PublicKey)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			bc := data.NewBuildRepo(tc.BuildClient(), tc.SecretClient())
+			buildService := app.NewBuild()
+			br, err := buildService.CreateAppBuild(bc, tc.Build)
+			if tc.ExpectError && err == nil {
+				t.Fatalf("expected an err but got none!")
+			}
+			if !tc.ExpectError && err != nil {
+				t.Fatalf("did not expect and err but got one %v", err)
+			}
+			if tc.Validate != nil {
+				tc.Validate(t, br)
+			}
+		})
+	}
+}

--- a/pkg/mobile/app/builds_test.go
+++ b/pkg/mobile/app/builds_test.go
@@ -8,13 +8,18 @@ import (
 	"github.com/feedhenry/mcp-standalone/pkg/data"
 	"github.com/feedhenry/mcp-standalone/pkg/mobile"
 	"github.com/feedhenry/mcp-standalone/pkg/mobile/app"
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/build"
 	"github.com/feedhenry/mcp-standalone/pkg/openshift/client"
 	"github.com/feedhenry/mcp-standalone/pkg/openshift/testclient"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/pkg/api/v1"
+	ktesting "k8s.io/client-go/testing"
 )
 
-func TestBuild_CreateAppBuild(t *testing.T) {
+func TestBuildCreateAppBuild(t *testing.T) {
 	cases := []struct {
 		Name         string
 		Build        *mobile.Build
@@ -35,6 +40,16 @@ func TestBuild_CreateAppBuild(t *testing.T) {
 			},
 			BuildClient: func() client.BuildConfigInterface {
 				fakeoc := testclient.NewFakeBuildConfigs("test", nil)
+				fakeoc.Fake.AddReactor("create", "buildconfigs", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					bc := action.(ktesting.CreateAction).GetObject().(*build.BuildConfig)
+					if nil == bc {
+						return true, nil, errors.New("no buildconfig passe")
+					}
+					if bc.Spec.Strategy.JenkinsPipelineStrategy.JenkinsfilePath != "Jenkinsfile" {
+						return true, nil, errors.New("expected the JenkinsfilePath to be : Jenkinsfile but got " + bc.Spec.Strategy.JenkinsPipelineStrategy.JenkinsfilePath)
+					}
+					return true, bc, nil
+				})
 				return fakeoc
 			},
 			SecretClient: func() corev1.SecretInterface {
@@ -54,7 +69,48 @@ func TestBuild_CreateAppBuild(t *testing.T) {
 			},
 		},
 		{
-			Name: "test create app build with no public private key",
+			Name: "test create app build with custom jenkinsfile location",
+			Build: &mobile.Build{
+				AppID: "test",
+				Name:  "test",
+				GitRepo: &mobile.BuildGitRepo{
+					URI:             "git@git.com",
+					Private:         true,
+					JenkinsFilePath: "/build/Jenkinsfile",
+				},
+			},
+			BuildClient: func() client.BuildConfigInterface {
+				fakeoc := testclient.NewFakeBuildConfigs("test", nil)
+				fakeoc.Fake.AddReactor("create", "buildconfigs", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					bc := action.(ktesting.CreateAction).GetObject().(*build.BuildConfig)
+					if nil == bc {
+						return true, nil, errors.New("no buildconfig passe")
+					}
+					if bc.Spec.Strategy.JenkinsPipelineStrategy.JenkinsfilePath != "/build/Jenkinsfile" {
+						return true, nil, errors.New("expected the JenkinsfilePath to be : /build/Jenkinsfile but got " + bc.Spec.Strategy.JenkinsPipelineStrategy.JenkinsfilePath)
+					}
+					return true, bc, nil
+				})
+				return fakeoc
+			},
+			SecretClient: func() corev1.SecretInterface {
+				fakec := &fake.Clientset{}
+				return fakec.CoreV1().Secrets("test")
+			},
+			Validate: func(t *testing.T, br *app.AppBuildCreatedResponse) {
+				if nil == br {
+					t.Fatal("expected an app build response but got nil")
+				}
+				if br.PublicKey == "" {
+					t.Fatal("expected a public key but it was empty")
+				}
+				if !strings.Contains(br.PublicKey, "PUBLIC KEY") {
+					t.Fatal("expected a public key but did not find public key comment ", br.PublicKey)
+				}
+			},
+		},
+		{
+			Name: "test create app build for public repo",
 			Build: &mobile.Build{
 				AppID: "test",
 				Name:  "test",
@@ -65,6 +121,16 @@ func TestBuild_CreateAppBuild(t *testing.T) {
 			},
 			BuildClient: func() client.BuildConfigInterface {
 				fakeoc := testclient.NewFakeBuildConfigs("test", nil)
+				fakeoc.Fake.AddReactor("create", "buildconfigs", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					bc := action.(ktesting.CreateAction).GetObject().(*build.BuildConfig)
+					if nil == bc {
+						return true, nil, errors.New("no buildconfig passe")
+					}
+					if bc.Spec.Strategy.JenkinsPipelineStrategy.JenkinsfilePath != "Jenkinsfile" {
+						return true, nil, errors.New("expected the JenkinsfilePath to be : Jenkinsfile but got " + bc.Spec.Strategy.JenkinsPipelineStrategy.JenkinsfilePath)
+					}
+					return true, bc, nil
+				})
 				return fakeoc
 			},
 			SecretClient: func() corev1.SecretInterface {
@@ -77,6 +143,34 @@ func TestBuild_CreateAppBuild(t *testing.T) {
 				}
 				if br.PublicKey != "" {
 					t.Fatalf("did not expect a public key but found %s ", br.PublicKey)
+				}
+			},
+		},
+		{
+			Name: "test create app build fails when cant create buildconfig",
+			Build: &mobile.Build{
+				AppID: "test",
+				Name:  "test",
+				GitRepo: &mobile.BuildGitRepo{
+					URI:     "git@git.com",
+					Private: false,
+				},
+			},
+			ExpectError: true,
+			BuildClient: func() client.BuildConfigInterface {
+				fakeoc := testclient.NewFakeBuildConfigs("test", nil)
+				fakeoc.Fake.AddReactor("create", "buildconfigs", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New("faield to create buildconfig")
+				})
+				return fakeoc
+			},
+			SecretClient: func() corev1.SecretInterface {
+				fakes := &fake.Clientset{}
+				return fakes.CoreV1().Secrets("test")
+			},
+			Validate: func(t *testing.T, br *app.AppBuildCreatedResponse) {
+				if nil != br {
+					t.Fatalf("expected no AppBuildCreatedResponse but got %v ", br)
 				}
 			},
 		},
@@ -96,6 +190,55 @@ func TestBuild_CreateAppBuild(t *testing.T) {
 			if tc.Validate != nil {
 				tc.Validate(t, br)
 			}
+		})
+	}
+}
+
+func TestBuildCreateBuildSrcKeySecret(t *testing.T) {
+	cases := []struct {
+		Name         string
+		ExpectError  bool
+		BuildClient  func() client.BuildConfigInterface
+		SecretClient func() corev1.SecretInterface
+	}{
+		{
+			Name: "test creating src key secret ok",
+			BuildClient: func() client.BuildConfigInterface {
+				fakeoc := testclient.NewFakeBuildConfigs("test", nil)
+				return fakeoc
+			},
+			SecretClient: func() corev1.SecretInterface {
+				fakec := &fake.Clientset{}
+				fakec.AddReactor("create", "secrets", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					secret := action.(ktesting.CreateAction).GetObject().(*v1.Secret)
+					return true, secret, nil
+
+				})
+				return fakec.CoreV1().Secrets("test")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+
+			br := data.NewBuildRepo(tc.BuildClient(), tc.SecretClient())
+			buildService := app.NewBuild()
+			secretName, pubKey, err := buildService.CreateBuildSrcKeySecret(br, "test", "test")
+			if tc.ExpectError && err == nil {
+				t.Fatalf("expected an err but got none!")
+			}
+			if !tc.ExpectError && err != nil {
+				t.Fatalf("did not expect and err but got one %v", err)
+			}
+			if !tc.ExpectError && secretName == "" {
+				t.Fatal("expected a secretname to be returned but found none")
+			}
+
+			if !tc.ExpectError && string(pubKey) == "" {
+				t.Fatalf("expected a public key to be returned but got none")
+			}
+
 		})
 	}
 }

--- a/pkg/mobile/integration/service.go
+++ b/pkg/mobile/integration/service.go
@@ -61,14 +61,14 @@ func (ms *MobileService) DiscoverMobileServices(serviceCruder mobile.ServiceCrud
 			if s.Namespace == "" {
 				s.Namespace = ms.namespace
 			}
-			s.Writeable = true
+			s.Writable = true
 		}
 		if s.External {
 			perm, err := authChecker.Check("deployments", s.Namespace, client)
 			if err != nil {
 				return nil, errors.Wrap(err, "error checking access permissions")
 			}
-			s.Writeable = perm
+			s.Writable = perm
 		}
 	}
 	return svc, nil
@@ -102,13 +102,13 @@ func (ms *MobileService) ReadMobileServiceAndIntegrations(serviceCruder mobile.S
 			}
 		}
 	}
-	svc.Writeable = true
+	svc.Writable = true
 	if svc.External {
 		perm, err := authChecker.Check("deployments", svc.Namespace, client)
 		if err != nil {
 			return nil, errors.Wrap(err, "error checking access permissions")
 		}
-		svc.Writeable = perm
+		svc.Writable = perm
 	}
 	return svc, nil
 }

--- a/pkg/mobile/interfaces.go
+++ b/pkg/mobile/interfaces.go
@@ -3,6 +3,7 @@ package mobile
 import (
 	"net/http"
 
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/client"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -26,6 +27,11 @@ type ServiceCruder interface {
 	Delete(serviceID string) error
 }
 
+type BuildCruder interface {
+	Create(b *Build) error
+	AddBuildAsset(b *Build, assetName string, keyValues map[string][]byte) (string, error)
+}
+
 type Attributer interface {
 	GetName() string
 	GetLabels() map[string]string
@@ -33,12 +39,20 @@ type Attributer interface {
 }
 
 //TODO probably not a core interface but rather we should wrap it inside the other repos as a dependency and have it consumed via the builders
-type ClientBuilder interface {
-	WithToken(token string) ClientBuilder
-	WithNamespace(ns string) ClientBuilder
-	WithHost(host string) ClientBuilder
-	WithHostAndNamespace(host, ns string) ClientBuilder
+type K8ClientBuilder interface {
+	WithToken(token string) K8ClientBuilder
+	WithNamespace(ns string) K8ClientBuilder
+	WithHost(host string) K8ClientBuilder
+	WithHostAndNamespace(host, ns string) K8ClientBuilder
 	BuildClient() (kubernetes.Interface, error)
+}
+
+type OSClientBuilder interface {
+	WithToken(token string) OSClientBuilder
+	WithNamespace(ns string) OSClientBuilder
+	WithHost(host string) OSClientBuilder
+	WithHostAndNamespace(host, ns string) OSClientBuilder
+	BuildClient() (client.Interface, error)
 }
 
 type AppRepoBuilder interface {
@@ -46,6 +60,13 @@ type AppRepoBuilder interface {
 	//UseDefaultSAToken delegates off to the service account token setup with the MCP. This should only be used for APIs where no real token is provided and should always be protected
 	UseDefaultSAToken() AppRepoBuilder
 	Build() (AppCruder, error)
+}
+
+type BuildRepoBuilder interface {
+	WithToken(token string) BuildRepoBuilder
+	//UseDefaultSAToken delegates off to the service account token setup with the MCP. This should only be used for APIs where no real token is provided and should always be protected
+	UseDefaultSAToken() BuildRepoBuilder
+	Build() (BuildCruder, error)
 }
 
 type UserRepoBuilder interface {

--- a/pkg/mobile/interfaces.go
+++ b/pkg/mobile/interfaces.go
@@ -29,7 +29,15 @@ type ServiceCruder interface {
 
 type BuildCruder interface {
 	Create(b *Build) error
-	AddBuildAsset(b *Build, assetName string, keyValues map[string][]byte) (string, error)
+	AddBuildAsset(asset BuildAsset) (string, error)
+}
+
+type BuildAsset struct {
+	BuildName string
+	AppName   string
+	Name      string
+	Type      BuildAssetType
+	AssetData map[string][]byte
 }
 
 type Attributer interface {
@@ -79,7 +87,6 @@ type UserRepo interface {
 	GetUser() (*User, error)
 }
 
-// TODO prob can remote the WithClient and instead use NewRepoBuilder(c corev1.ConfigMapInterface) and have this just expose Build() and perhaps add WithToken(token string)
 type ServiceRepoBuilder interface {
 	WithToken(token string) ServiceRepoBuilder
 	//UseDefaultSAToken delegates off to the service account token setup with the MCP. This should only be used for APIs where no real token is provided and should always be protected

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -32,7 +32,22 @@ type Service struct {
 	Labels       map[string]string              `json:"labels"`
 	Integrations map[string]*ServiceIntegration `json:"integrations"`
 	External     bool                           `json:"external"`
-	Writeable    bool                           `json:"writeable"`
+	Writable     bool                           `json:"writable"`
+}
+
+// Build represents a build of a mobile client. It is converted to a buildconfig
+type Build struct {
+	AppID   string        `json:"appID"`
+	Name    string        `json:"name"`
+	GitRepo *BuildGitRepo `json:"gitRepo"`
+}
+
+type BuildGitRepo struct {
+	URI         string `json:"uri"`
+	Private     bool   `json:"private"`
+	Ref         string `json:"ref"`
+	PublicKey   string `json:"public"`
+	PublicKeyID string `json:"public_key_id"`
 }
 
 func NewMobileService() *Service {

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -43,12 +43,20 @@ type Build struct {
 }
 
 type BuildGitRepo struct {
-	URI         string `json:"uri"`
-	Private     bool   `json:"private"`
-	Ref         string `json:"ref"`
-	PublicKey   string `json:"public"`
-	PublicKeyID string `json:"public_key_id"`
+	URI             string `json:"uri"`
+	Private         bool   `json:"private"`
+	Ref             string `json:"ref"`
+	PublicKey       string `json:"public"`
+	PublicKeyID     string `json:"publicKeyId"`
+	JenkinsFilePath string `json:"jenkinsFilePath"`
 }
+
+type BuildAssetType string
+
+var (
+	BuildAssetTypeSourceCredential BuildAssetType = "mobile-src"
+	BuildAssetTypeBuildSecret      BuildAssetType = "mobile-build"
+)
 
 func NewMobileService() *Service {
 	return &Service{

--- a/pkg/mock/mockClientBuilder.go
+++ b/pkg/mock/mockClientBuilder.go
@@ -2,9 +2,13 @@ package mock
 
 import (
 	"github.com/feedhenry/mcp-standalone/pkg/mobile"
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/client"
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/testclient"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/testing"
 )
 
+// ClientBuilder is a mock kubernetes client builder
 type ClientBuilder struct {
 	token      string
 	namespace  string
@@ -12,19 +16,53 @@ type ClientBuilder struct {
 	Fakeclient kubernetes.Interface
 }
 
-func (cb *ClientBuilder) WithToken(token string) mobile.ClientBuilder {
+func (cb *ClientBuilder) WithToken(token string) mobile.K8ClientBuilder {
 	return &ClientBuilder{token: token, host: cb.host, namespace: cb.namespace, Fakeclient: cb.Fakeclient}
 }
-func (cb *ClientBuilder) WithNamespace(ns string) mobile.ClientBuilder {
+func (cb *ClientBuilder) WithNamespace(ns string) mobile.K8ClientBuilder {
 	return &ClientBuilder{token: cb.token, host: cb.host, namespace: ns, Fakeclient: cb.Fakeclient}
 }
-func (cb *ClientBuilder) WithHost(host string) mobile.ClientBuilder {
+func (cb *ClientBuilder) WithHost(host string) mobile.K8ClientBuilder {
 	return &ClientBuilder{token: cb.token, host: host, namespace: cb.namespace, Fakeclient: cb.Fakeclient}
 }
-func (cb *ClientBuilder) WithHostAndNamespace(host, ns string) mobile.ClientBuilder {
+func (cb *ClientBuilder) WithHostAndNamespace(host, ns string) mobile.K8ClientBuilder {
 	return &ClientBuilder{token: cb.token, host: host, namespace: ns, Fakeclient: cb.Fakeclient}
 }
 func (cb *ClientBuilder) BuildClient() (kubernetes.Interface, error) {
 	return cb.Fakeclient, nil
+
+}
+
+// OCClientBuilder is a mock openshift client bulder
+type OCClientBuilder struct {
+	token     string
+	namespace string
+	host      string
+	Fake      *testing.Fake
+}
+
+func NewOCClientBuilder(token, namespace, host string, fake *testing.Fake) *OCClientBuilder {
+	return &OCClientBuilder{
+		token:     token,
+		namespace: namespace,
+		host:      host,
+		Fake:      fake,
+	}
+}
+
+func (cb *OCClientBuilder) WithToken(token string) mobile.OSClientBuilder {
+	return &OCClientBuilder{token: token, host: cb.host, namespace: cb.namespace, Fake: cb.Fake}
+}
+func (cb *OCClientBuilder) WithNamespace(ns string) mobile.OSClientBuilder {
+	return &OCClientBuilder{token: cb.token, host: cb.host, namespace: ns, Fake: cb.Fake}
+}
+func (cb *OCClientBuilder) WithHost(host string) mobile.OSClientBuilder {
+	return &OCClientBuilder{token: cb.token, host: host, namespace: cb.namespace, Fake: cb.Fake}
+}
+func (cb *OCClientBuilder) WithHostAndNamespace(host, ns string) mobile.OSClientBuilder {
+	return &OCClientBuilder{token: cb.token, host: host, namespace: ns, Fake: cb.Fake}
+}
+func (cb *OCClientBuilder) BuildClient() (client.Interface, error) {
+	return testclient.NewClient(cb.host, cb.namespace, cb.token, cb.Fake), nil
 
 }

--- a/pkg/openshift/README.md
+++ b/pkg/openshift/README.md
@@ -1,0 +1,3 @@
+Note this package is here until the oc go client is separated from the openshift code base.
+This is due in 3.7 of OSCP. It is worth waiting to avoid having to vendor most of the Openshift  and kubernetes code base.
+But will be removed once 3.7 lands

--- a/pkg/openshift/build/types.go
+++ b/pkg/openshift/build/types.go
@@ -1,0 +1,1182 @@
+package build
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kapi "k8s.io/client-go/pkg/api/v1"
+)
+
+// +genclient
+// +genclient:method=UpdateDetails,verb=update,subresource=details
+// +genclient:method=Clone,verb=create,subresource=clone,input=BuildRequest
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// Build encapsulates the inputs needed to produce a new deployable image, as well as
+// the status of the execution and a reference to the Pod which executed the build.
+type Build struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// spec is all the inputs used to execute the build.
+	Spec BuildSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
+
+	// status is the current status of the build.
+	Status BuildStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+}
+
+// BuildSpec has the information to represent a build and also additional
+// information about a build
+type BuildSpec struct {
+	// CommonSpec is the information that represents a build
+	CommonSpec `json:",inline" protobuf:"bytes,1,opt,name=commonSpec"`
+
+	// triggeredBy describes which triggers started the most recent update to the
+	// build configuration and contains information about those triggers.
+	TriggeredBy []BuildTriggerCause `json:"triggeredBy" protobuf:"bytes,2,rep,name=triggeredBy"`
+}
+
+// OptionalNodeSelector is a map that may also be left nil to distinguish between set and unset.
+// +protobuf.nullable=true
+// +protobuf.options.(gogoproto.goproto_stringer)=false
+type OptionalNodeSelector map[string]string
+
+func (t OptionalNodeSelector) String() string {
+	return fmt.Sprintf("%v", map[string]string(t))
+}
+
+// CommonSpec encapsulates all the inputs necessary to represent a build.
+type CommonSpec struct {
+	// serviceAccount is the name of the ServiceAccount to use to run the pod
+	// created by this build.
+	// The pod will be allowed to use secrets referenced by the ServiceAccount
+	ServiceAccount string `json:"serviceAccount,omitempty" protobuf:"bytes,1,opt,name=serviceAccount"`
+
+	// source describes the SCM in use.
+	Source BuildSource `json:"source,omitempty" protobuf:"bytes,2,opt,name=source"`
+
+	// revision is the information from the source for a specific repo snapshot.
+	// This is optional.
+	Revision *SourceRevision `json:"revision,omitempty" protobuf:"bytes,3,opt,name=revision"`
+
+	// strategy defines how to perform a build.
+	Strategy BuildStrategy `json:"strategy" protobuf:"bytes,4,opt,name=strategy"`
+
+	// output describes the Docker image the Strategy should produce.
+	Output BuildOutput `json:"output,omitempty" protobuf:"bytes,5,opt,name=output"`
+
+	// resources computes resource requirements to execute the build.
+	Resources kapi.ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,6,opt,name=resources"`
+
+	// postCommit is a build hook executed after the build output image is
+	// committed, before it is pushed to a registry.
+	PostCommit BuildPostCommitSpec `json:"postCommit,omitempty" protobuf:"bytes,7,opt,name=postCommit"`
+
+	// completionDeadlineSeconds is an optional duration in seconds, counted from
+	// the time when a build pod gets scheduled in the system, that the build may
+	// be active on a node before the system actively tries to terminate the
+	// build; value must be positive integer
+	CompletionDeadlineSeconds *int64 `json:"completionDeadlineSeconds,omitempty" protobuf:"varint,8,opt,name=completionDeadlineSeconds"`
+
+	// nodeSelector is a selector which must be true for the build pod to fit on a node
+	// If nil, it can be overridden by default build nodeselector values for the cluster.
+	// If set to an empty map or a map with any values, default build nodeselector values
+	// are ignored.
+	NodeSelector OptionalNodeSelector `json:"nodeSelector" protobuf:"bytes,9,name=nodeSelector"`
+}
+
+// BuildTriggerCause holds information about a triggered build. It is used for
+// displaying build trigger data for each build and build configuration in oc
+// describe. It is also used to describe which triggers led to the most recent
+// update in the build configuration.
+type BuildTriggerCause struct {
+	// message is used to store a human readable message for why the build was
+	// triggered. E.g.: "Manually triggered by user", "Configuration change",etc.
+	Message string `json:"message,omitempty" protobuf:"bytes,1,opt,name=message"`
+
+	// genericWebHook holds data about a builds generic webhook trigger.
+	GenericWebHook *GenericWebHookCause `json:"genericWebHook,omitempty" protobuf:"bytes,2,opt,name=genericWebHook"`
+
+	// gitHubWebHook represents data for a GitHub webhook that fired a
+	//specific build.
+	GitHubWebHook *GitHubWebHookCause `json:"githubWebHook,omitempty" protobuf:"bytes,3,opt,name=githubWebHook"`
+
+	// imageChangeBuild stores information about an imagechange event
+	// that triggered a new build.
+	ImageChangeBuild *ImageChangeCause `json:"imageChangeBuild,omitempty" protobuf:"bytes,4,opt,name=imageChangeBuild"`
+
+	// GitLabWebHook represents data for a GitLab webhook that fired a specific
+	// build.
+	GitLabWebHook *GitLabWebHookCause `json:"gitlabWebHook,omitempty" protobuf:"bytes,5,opt,name=gitlabWebHook"`
+
+	// BitbucketWebHook represents data for a Bitbucket webhook that fired a
+	// specific build.
+	BitbucketWebHook *BitbucketWebHookCause `json:"bitbucketWebHook,omitempty" protobuf:"bytes,6,opt,name=bitbucketWebHook"`
+}
+
+// GenericWebHookCause holds information about a generic WebHook that
+// triggered a build.
+type GenericWebHookCause struct {
+	// revision is an optional field that stores the git source revision
+	// information of the generic webhook trigger when it is available.
+	Revision *SourceRevision `json:"revision,omitempty" protobuf:"bytes,1,opt,name=revision"`
+
+	// secret is the obfuscated webhook secret that triggered a build.
+	Secret string `json:"secret,omitempty" protobuf:"bytes,2,opt,name=secret"`
+}
+
+// GitHubWebHookCause has information about a GitHub webhook that triggered a
+// build.
+type GitHubWebHookCause struct {
+	// revision is the git revision information of the trigger.
+	Revision *SourceRevision `json:"revision,omitempty" protobuf:"bytes,1,opt,name=revision"`
+
+	// secret is the obfuscated webhook secret that triggered a build.
+	Secret string `json:"secret,omitempty" protobuf:"bytes,2,opt,name=secret"`
+}
+
+// CommonWebHookCause factors out the identical format of these webhook
+// causes into struct so we can share it in the specific causes;  it is too late for
+// GitHub and Generic but we can leverage this pattern with GitLab and Bitbucket.
+type CommonWebHookCause struct {
+	// Revision is the git source revision information of the trigger.
+	Revision *SourceRevision `json:"revision,omitempty" protobuf:"bytes,1,opt,name=revision"`
+
+	// Secret is the obfuscated webhook secret that triggered a build.
+	Secret string `json:"secret,omitempty" protobuf:"bytes,2,opt,name=secret"`
+}
+
+// GitLabWebHookCause has information about a GitLab webhook that triggered a
+// build.
+type GitLabWebHookCause struct {
+	CommonWebHookCause `json:",inline" protobuf:"bytes,1,opt,name=commonSpec"`
+}
+
+// BitbucketWebHookCause has information about a Bitbucket webhook that triggered a
+// build.
+type BitbucketWebHookCause struct {
+	CommonWebHookCause `json:",inline" protobuf:"bytes,1,opt,name=commonSpec"`
+}
+
+// ImageChangeCause contains information about the image that triggered a
+// build
+type ImageChangeCause struct {
+	// imageID is the ID of the image that triggered a a new build.
+	ImageID string `json:"imageID,omitempty" protobuf:"bytes,1,opt,name=imageID"`
+
+	// fromRef contains detailed information about an image that triggered a
+	// build.
+	FromRef *kapi.ObjectReference `json:"fromRef,omitempty" protobuf:"bytes,2,opt,name=fromRef"`
+}
+
+// BuildStatus contains the status of a build
+type BuildStatus struct {
+	// phase is the point in the build lifecycle. Possible values are
+	// "New", "Pending", "Running", "Complete", "Failed", "Error", and "Cancelled".
+	Phase BuildPhase `json:"phase" protobuf:"bytes,1,opt,name=phase,casttype=BuildPhase"`
+
+	// cancelled describes if a cancel event was triggered for the build.
+	Cancelled bool `json:"cancelled,omitempty" protobuf:"varint,2,opt,name=cancelled"`
+
+	// reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.
+	Reason StatusReason `json:"reason,omitempty" protobuf:"bytes,3,opt,name=reason,casttype=StatusReason"`
+
+	// message is a human-readable message indicating details about why the build has this status.
+	Message string `json:"message,omitempty" protobuf:"bytes,4,opt,name=message"`
+
+	// startTimestamp is a timestamp representing the server time when this Build started
+	// running in a Pod.
+	// It is represented in RFC3339 form and is in UTC.
+	StartTimestamp *metav1.Time `json:"startTimestamp,omitempty" protobuf:"bytes,5,opt,name=startTimestamp"`
+
+	// completionTimestamp is a timestamp representing the server time when this Build was
+	// finished, whether that build failed or succeeded.  It reflects the time at which
+	// the Pod running the Build terminated.
+	// It is represented in RFC3339 form and is in UTC.
+	CompletionTimestamp *metav1.Time `json:"completionTimestamp,omitempty" protobuf:"bytes,6,opt,name=completionTimestamp"`
+
+	// duration contains time.Duration object describing build time.
+	Duration time.Duration `json:"duration,omitempty" protobuf:"varint,7,opt,name=duration,casttype=time.Duration"`
+
+	// outputDockerImageReference contains a reference to the Docker image that
+	// will be built by this build. Its value is computed from
+	// Build.Spec.Output.To, and should include the registry address, so that
+	// it can be used to push and pull the image.
+	OutputDockerImageReference string `json:"outputDockerImageReference,omitempty" protobuf:"bytes,8,opt,name=outputDockerImageReference"`
+
+	// config is an ObjectReference to the BuildConfig this Build is based on.
+	Config *kapi.ObjectReference `json:"config,omitempty" protobuf:"bytes,9,opt,name=config"`
+
+	// output describes the Docker image the build has produced.
+	Output BuildStatusOutput `json:"output,omitempty" protobuf:"bytes,10,opt,name=output"`
+
+	// stages contains details about each stage that occurs during the build
+	// including start time, duration (in milliseconds), and the steps that
+	// occured within each stage.
+	Stages []StageInfo `json:"stages,omitempty" protobuf:"bytes,11,opt,name=stages"`
+
+	// logSnippet is the last few lines of the build log.  This value is only set for builds that failed.
+	LogSnippet string `json:"logSnippet,omitempty" protobuf:"bytes,12,opt,name=logSnippet"`
+}
+
+// StageInfo contains details about a build stage.
+type StageInfo struct {
+	// name is a unique identifier for each build stage that occurs.
+	Name StageName `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+
+	// startTime is a timestamp representing the server time when this Stage started.
+	// It is represented in RFC3339 form and is in UTC.
+	StartTime metav1.Time `json:"startTime,omitempty" protobuf:"bytes,2,opt,name=startTime"`
+
+	// durationMilliseconds identifies how long the stage took
+	// to complete in milliseconds.
+	// Note: the duration of a stage can exceed the sum of the duration of the steps within
+	// the stage as not all actions are accounted for in explicit build steps.
+	DurationMilliseconds int64 `json:"durationMilliseconds,omitempty" protobuf:"varint,3,opt,name=durationMilliseconds"`
+
+	// steps contains details about each step that occurs during a build stage
+	// including start time and duration in milliseconds.
+	Steps []StepInfo `json:"steps,omitempty" protobuf:"bytes,4,opt,name=steps"`
+}
+
+// StageName is the unique identifier for each build stage.
+type StageName string
+
+// Valid values for StageName
+const (
+	// StageFetchInputs fetches any inputs such as source code.
+	StageFetchInputs StageName = "FetchInputs"
+
+	// StagePullImages pulls any images that are needed such as
+	// base images or input images.
+	StagePullImages StageName = "PullImages"
+
+	// StageBuild performs the steps necessary to build the image.
+	StageBuild StageName = "Build"
+
+	// StagePostCommit executes any post commit steps.
+	StagePostCommit StageName = "PostCommit"
+
+	// StagePushImage pushes the image to the node.
+	StagePushImage StageName = "PushImage"
+)
+
+// StepInfo contains details about a build step.
+type StepInfo struct {
+	// name is a unique identifier for each build step.
+	Name StepName `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+
+	// startTime is a timestamp representing the server time when this Step started.
+	// it is represented in RFC3339 form and is in UTC.
+	StartTime metav1.Time `json:"startTime,omitempty" protobuf:"bytes,2,opt,name=startTime"`
+
+	// durationMilliseconds identifies how long the step took
+	// to complete in milliseconds.
+	DurationMilliseconds int64 `json:"durationMilliseconds,omitempty" protobuf:"varint,3,opt,name=durationMilliseconds"`
+}
+
+// StepName is a unique identifier for each build step.
+type StepName string
+
+// Valid values for StepName
+const (
+	// StepExecPostCommitHook executes the buildconfigs post commit hook.
+	StepExecPostCommitHook StepName = "RunPostCommitHook"
+
+	// StepFetchGitSource fetches source code for the build.
+	StepFetchGitSource StepName = "FetchGitSource"
+
+	// StepPullBaseImage pulls a base image for the build.
+	StepPullBaseImage StepName = "PullBaseImage"
+
+	// StepPullInputImage pulls an input image for the build.
+	StepPullInputImage StepName = "PullInputImage"
+
+	// StepPushImage pushes an image to the registry.
+	StepPushImage StepName = "PushImage"
+
+	// StepPushDockerImage pushes a docker image to the registry.
+	StepPushDockerImage StepName = "PushDockerImage"
+
+	//StepDockerBuild performs the docker build
+	StepDockerBuild StepName = "DockerBuild"
+)
+
+// BuildPhase represents the status of a build at a point in time.
+type BuildPhase string
+
+// Valid values for BuildPhase.
+const (
+	// BuildPhaseNew is automatically assigned to a newly created build.
+	BuildPhaseNew BuildPhase = "New"
+
+	// BuildPhasePending indicates that a pod name has been assigned and a build is
+	// about to start running.
+	BuildPhasePending BuildPhase = "Pending"
+
+	// BuildPhaseRunning indicates that a pod has been created and a build is running.
+	BuildPhaseRunning BuildPhase = "Running"
+
+	// BuildPhaseComplete indicates that a build has been successful.
+	BuildPhaseComplete BuildPhase = "Complete"
+
+	// BuildPhaseFailed indicates that a build has executed and failed.
+	BuildPhaseFailed BuildPhase = "Failed"
+
+	// BuildPhaseError indicates that an error prevented the build from executing.
+	BuildPhaseError BuildPhase = "Error"
+
+	// BuildPhaseCancelled indicates that a running/pending build was stopped from executing.
+	BuildPhaseCancelled BuildPhase = "Cancelled"
+)
+
+// StatusReason is a brief CamelCase string that describes a temporary or
+// permanent build error condition, meant for machine parsing and tidy display
+// in the CLI.
+type StatusReason string
+
+// BuildStatusOutput contains the status of the built image.
+type BuildStatusOutput struct {
+	// to describes the status of the built image being pushed to a registry.
+	To *BuildStatusOutputTo `json:"to,omitempty" protobuf:"bytes,1,opt,name=to"`
+}
+
+// BuildStatusOutputTo describes the status of the built image with regards to
+// image registry to which it was supposed to be pushed.
+type BuildStatusOutputTo struct {
+	// imageDigest is the digest of the built Docker image. The digest uniquely
+	// identifies the image in the registry to which it was pushed.
+	//
+	// Please note that this field may not always be set even if the push
+	// completes successfully - e.g. when the registry returns no digest or
+	// returns it in a format that the builder doesn't understand.
+	ImageDigest string `json:"imageDigest,omitempty" protobuf:"bytes,1,opt,name=imageDigest"`
+}
+
+// BuildSourceType is the type of SCM used.
+type BuildSourceType string
+
+// Valid values for BuildSourceType.
+const (
+	//BuildSourceGit instructs a build to use a Git source control repository as the build input.
+	BuildSourceGit BuildSourceType = "Git"
+	// BuildSourceDockerfile uses a Dockerfile as the start of a build
+	BuildSourceDockerfile BuildSourceType = "Dockerfile"
+	// BuildSourceBinary indicates the build will accept a Binary file as input.
+	BuildSourceBinary BuildSourceType = "Binary"
+	// BuildSourceImage indicates the build will accept an image as input
+	BuildSourceImage BuildSourceType = "Image"
+	// BuildSourceNone indicates the build has no predefined input (only valid for Source and Custom Strategies)
+	BuildSourceNone BuildSourceType = "None"
+)
+
+// BuildSource is the SCM used for the build.
+type BuildSource struct {
+	// type of build input to accept
+	// +k8s:conversion-gen=false
+	Type BuildSourceType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=BuildSourceType"`
+
+	// binary builds accept a binary as their input. The binary is generally assumed to be a tar,
+	// gzipped tar, or zip file depending on the strategy. For Docker builds, this is the build
+	// context and an optional Dockerfile may be specified to override any Dockerfile in the
+	// build context. For Source builds, this is assumed to be an archive as described above. For
+	// Source and Docker builds, if binary.asFile is set the build will receive a directory with
+	// a single file. contextDir may be used when an archive is provided. Custom builds will
+	// receive this binary as input on STDIN.
+	Binary *BinaryBuildSource `json:"binary,omitempty" protobuf:"bytes,2,opt,name=binary"`
+
+	// dockerfile is the raw contents of a Dockerfile which should be built. When this option is
+	// specified, the FROM may be modified based on your strategy base image and additional ENV
+	// stanzas from your strategy environment will be added after the FROM, but before the rest
+	// of your Dockerfile stanzas. The Dockerfile source type may be used with other options like
+	// git - in those cases the Git repo will have any innate Dockerfile replaced in the context
+	// dir.
+	Dockerfile *string `json:"dockerfile,omitempty" protobuf:"bytes,3,opt,name=dockerfile"`
+
+	// git contains optional information about git build source
+	Git *GitBuildSource `json:"git,omitempty" protobuf:"bytes,4,opt,name=git"`
+
+	// images describes a set of images to be used to provide source for the build
+	Images []ImageSource `json:"images,omitempty" protobuf:"bytes,5,rep,name=images"`
+
+	// contextDir specifies the sub-directory where the source code for the application exists.
+	// This allows to have buildable sources in directory other than root of
+	// repository.
+	ContextDir string `json:"contextDir,omitempty" protobuf:"bytes,6,opt,name=contextDir"`
+
+	// sourceSecret is the name of a Secret that would be used for setting
+	// up the authentication for cloning private repository.
+	// The secret contains valid credentials for remote repository, where the
+	// data's key represent the authentication method to be used and value is
+	// the base64 encoded credentials. Supported auth methods are: ssh-privatekey.
+	SourceSecret *kapi.LocalObjectReference `json:"sourceSecret,omitempty" protobuf:"bytes,7,opt,name=sourceSecret"`
+
+	// secrets represents a list of secrets and their destinations that will
+	// be used only for the build.
+	Secrets []SecretBuildSource `json:"secrets,omitempty" protobuf:"bytes,8,rep,name=secrets"`
+}
+
+// ImageSource is used to describe build source that will be extracted from an image. A reference of
+// type ImageStreamTag, ImageStreamImage or DockerImage may be used. A pull secret can be specified
+// to pull the image from an external registry or override the default service account secret if pulling
+// from the internal registry. A list of paths to copy from the image and their respective destination
+// within the build directory must be specified in the paths array.
+type ImageSource struct {
+	// from is a reference to an ImageStreamTag, ImageStreamImage, or DockerImage to
+	// copy source from.
+	From kapi.ObjectReference `json:"from" protobuf:"bytes,1,opt,name=from"`
+
+	// paths is a list of source and destination paths to copy from the image.
+	Paths []ImageSourcePath `json:"paths" protobuf:"bytes,2,rep,name=paths"`
+
+	// pullSecret is a reference to a secret to be used to pull the image from a registry
+	// If the image is pulled from the OpenShift registry, this field does not need to be set.
+	PullSecret *kapi.LocalObjectReference `json:"pullSecret,omitempty" protobuf:"bytes,3,opt,name=pullSecret"`
+}
+
+// ImageSourcePath describes a path to be copied from a source image and its destination within the build directory.
+type ImageSourcePath struct {
+	// sourcePath is the absolute path of the file or directory inside the image to
+	// copy to the build directory.  If the source path ends in /. then the content of
+	// the directory will be copied, but the directory itself will not be created at the
+	// destination.
+	SourcePath string `json:"sourcePath" protobuf:"bytes,1,opt,name=sourcePath"`
+
+	// destinationDir is the relative directory within the build directory
+	// where files copied from the image are placed.
+	DestinationDir string `json:"destinationDir" protobuf:"bytes,2,opt,name=destinationDir"`
+}
+
+// SecretBuildSource describes a secret and its destination directory that will be
+// used only at the build time. The content of the secret referenced here will
+// be copied into the destination directory instead of mounting.
+type SecretBuildSource struct {
+	// secret is a reference to an existing secret that you want to use in your
+	// build.
+	Secret kapi.LocalObjectReference `json:"secret" protobuf:"bytes,1,opt,name=secret"`
+
+	// destinationDir is the directory where the files from the secret should be
+	// available for the build time.
+	// For the Source build strategy, these will be injected into a container
+	// where the assemble script runs. Later, when the script finishes, all files
+	// injected will be truncated to zero length.
+	// For the Docker build strategy, these will be copied into the build
+	// directory, where the Dockerfile is located, so users can ADD or COPY them
+	// during docker build.
+	DestinationDir string `json:"destinationDir,omitempty" protobuf:"bytes,2,opt,name=destinationDir"`
+}
+
+// BinaryBuildSource describes a binary file to be used for the Docker and Source build strategies,
+// where the file will be extracted and used as the build source.
+type BinaryBuildSource struct {
+	// asFile indicates that the provided binary input should be considered a single file
+	// within the build input. For example, specifying "webapp.war" would place the provided
+	// binary as `/webapp.war` for the builder. If left empty, the Docker and Source build
+	// strategies assume this file is a zip, tar, or tar.gz file and extract it as the source.
+	// The custom strategy receives this binary as standard input. This filename may not
+	// contain slashes or be '..' or '.'.
+	AsFile string `json:"asFile,omitempty" protobuf:"bytes,1,opt,name=asFile"`
+}
+
+// SourceRevision is the revision or commit information from the source for the build
+type SourceRevision struct {
+	// type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'
+	// +k8s:conversion-gen=false
+	Type BuildSourceType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=BuildSourceType"`
+
+	// Git contains information about git-based build source
+	Git *GitSourceRevision `json:"git,omitempty" protobuf:"bytes,2,opt,name=git"`
+}
+
+// GitSourceRevision is the commit information from a git source for a build
+type GitSourceRevision struct {
+	// commit is the commit hash identifying a specific commit
+	Commit string `json:"commit,omitempty" protobuf:"bytes,1,opt,name=commit"`
+
+	// author is the author of a specific commit
+	Author SourceControlUser `json:"author,omitempty" protobuf:"bytes,2,opt,name=author"`
+
+	// committer is the committer of a specific commit
+	Committer SourceControlUser `json:"committer,omitempty" protobuf:"bytes,3,opt,name=committer"`
+
+	// message is the description of a specific commit
+	Message string `json:"message,omitempty" protobuf:"bytes,4,opt,name=message"`
+}
+
+// ProxyConfig defines what proxies to use for an operation
+type ProxyConfig struct {
+	// httpProxy is a proxy used to reach the git repository over http
+	HTTPProxy *string `json:"httpProxy,omitempty" protobuf:"bytes,3,opt,name=httpProxy"`
+
+	// httpsProxy is a proxy used to reach the git repository over https
+	HTTPSProxy *string `json:"httpsProxy,omitempty" protobuf:"bytes,4,opt,name=httpsProxy"`
+
+	// noProxy is the list of domains for which the proxy should not be used
+	NoProxy *string `json:"noProxy,omitempty" protobuf:"bytes,5,opt,name=noProxy"`
+}
+
+// GitBuildSource defines the parameters of a Git SCM
+type GitBuildSource struct {
+	// uri points to the source that will be built. The structure of the source
+	// will depend on the type of build to run
+	URI string `json:"uri" protobuf:"bytes,1,opt,name=uri"`
+
+	// ref is the branch/tag/ref to build.
+	Ref string `json:"ref,omitempty" protobuf:"bytes,2,opt,name=ref"`
+
+	// proxyConfig defines the proxies to use for the git clone operation
+	ProxyConfig `json:",inline" protobuf:"bytes,3,opt,name=proxyConfig"`
+}
+
+// SourceControlUser defines the identity of a user of source control
+type SourceControlUser struct {
+	// name of the source control user
+	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+
+	// email of the source control user
+	Email string `json:"email,omitempty" protobuf:"bytes,2,opt,name=email"`
+}
+
+// BuildStrategy contains the details of how to perform a build.
+type BuildStrategy struct {
+	// type is the kind of build strategy.
+	// +k8s:conversion-gen=false
+	Type BuildStrategyType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=BuildStrategyType"`
+
+	// dockerStrategy holds the parameters to the Docker build strategy.
+	DockerStrategy *DockerBuildStrategy `json:"dockerStrategy,omitempty" protobuf:"bytes,2,opt,name=dockerStrategy"`
+
+	// sourceStrategy holds the parameters to the Source build strategy.
+	SourceStrategy *SourceBuildStrategy `json:"sourceStrategy,omitempty" protobuf:"bytes,3,opt,name=sourceStrategy"`
+
+	// customStrategy holds the parameters to the Custom build strategy
+	CustomStrategy *CustomBuildStrategy `json:"customStrategy,omitempty" protobuf:"bytes,4,opt,name=customStrategy"`
+
+	// JenkinsPipelineStrategy holds the parameters to the Jenkins Pipeline build strategy.
+	// This strategy is in tech preview.
+	JenkinsPipelineStrategy *JenkinsPipelineBuildStrategy `json:"jenkinsPipelineStrategy,omitempty" protobuf:"bytes,5,opt,name=jenkinsPipelineStrategy"`
+}
+
+// BuildStrategyType describes a particular way of performing a build.
+type BuildStrategyType string
+
+// Valid values for BuildStrategyType.
+const (
+	// DockerBuildStrategyType performs builds using a Dockerfile.
+	DockerBuildStrategyType BuildStrategyType = "Docker"
+
+	// SourceBuildStrategyType performs builds build using Source To Images with a Git repository
+	// and a builder image.
+	SourceBuildStrategyType BuildStrategyType = "Source"
+
+	// CustomBuildStrategyType performs builds using custom builder Docker image.
+	CustomBuildStrategyType BuildStrategyType = "Custom"
+
+	// JenkinsPipelineBuildStrategyType indicates the build will run via Jenkine Pipeline.
+	JenkinsPipelineBuildStrategyType BuildStrategyType = "JenkinsPipeline"
+)
+
+// CustomBuildStrategy defines input parameters specific to Custom build.
+type CustomBuildStrategy struct {
+	// from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which
+	// the docker image should be pulled
+	From kapi.ObjectReference `json:"from" protobuf:"bytes,1,opt,name=from"`
+
+	// pullSecret is the name of a Secret that would be used for setting up
+	// the authentication for pulling the Docker images from the private Docker
+	// registries
+	PullSecret *kapi.LocalObjectReference `json:"pullSecret,omitempty" protobuf:"bytes,2,opt,name=pullSecret"`
+
+	// env contains additional environment variables you want to pass into a builder container.
+	Env []kapi.EnvVar `json:"env,omitempty" protobuf:"bytes,3,rep,name=env"`
+
+	// exposeDockerSocket will allow running Docker commands (and build Docker images) from
+	// inside the Docker container.
+	// TODO: Allow admins to enforce 'false' for this option
+	ExposeDockerSocket bool `json:"exposeDockerSocket,omitempty" protobuf:"varint,4,opt,name=exposeDockerSocket"`
+
+	// forcePull describes if the controller should configure the build pod to always pull the images
+	// for the builder or only pull if it is not present locally
+	ForcePull bool `json:"forcePull,omitempty" protobuf:"varint,5,opt,name=forcePull"`
+
+	// secrets is a list of additional secrets that will be included in the build pod
+	Secrets []SecretSpec `json:"secrets,omitempty" protobuf:"bytes,6,rep,name=secrets"`
+
+	// buildAPIVersion is the requested API version for the Build object serialized and passed to the custom builder
+	BuildAPIVersion string `json:"buildAPIVersion,omitempty" protobuf:"bytes,7,opt,name=buildAPIVersion"`
+}
+
+// ImageOptimizationPolicy describes what optimizations the builder can perform when building images.
+type ImageOptimizationPolicy string
+
+const (
+	// ImageOptimizationNone will generate a canonical Docker image as produced by the
+	// `docker build` command.
+	ImageOptimizationNone ImageOptimizationPolicy = "None"
+
+	// ImageOptimizationSkipLayers is an experimental policy and will avoid creating
+	// unique layers for each dockerfile line, resulting in smaller images and saving time
+	// during creation. Some Dockerfile syntax is not fully supported - content added to
+	// a VOLUME by an earlier layer may have incorrect uid, gid, and filesystem permissions.
+	// If an unsupported setting is detected, the build will fail.
+	ImageOptimizationSkipLayers ImageOptimizationPolicy = "SkipLayers"
+
+	// ImageOptimizationSkipLayersAndWarn is the same as SkipLayers, but will only
+	// warn to the build output instead of failing when unsupported syntax is detected. This
+	// policy is experimental.
+	ImageOptimizationSkipLayersAndWarn ImageOptimizationPolicy = "SkipLayersAndWarn"
+)
+
+// DockerBuildStrategy defines input parameters specific to Docker build.
+type DockerBuildStrategy struct {
+	// from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which
+	// the docker image should be pulled
+	// the resulting image will be used in the FROM line of the Dockerfile for this build.
+	From *kapi.ObjectReference `json:"from,omitempty" protobuf:"bytes,1,opt,name=from"`
+
+	// pullSecret is the name of a Secret that would be used for setting up
+	// the authentication for pulling the Docker images from the private Docker
+	// registries
+	PullSecret *kapi.LocalObjectReference `json:"pullSecret,omitempty" protobuf:"bytes,2,opt,name=pullSecret"`
+
+	// noCache if set to true indicates that the docker build must be executed with the
+	// --no-cache=true flag
+	NoCache bool `json:"noCache,omitempty" protobuf:"varint,3,opt,name=noCache"`
+
+	// env contains additional environment variables you want to pass into a builder container.
+	Env []kapi.EnvVar `json:"env,omitempty" protobuf:"bytes,4,rep,name=env"`
+
+	// forcePull describes if the builder should pull the images from registry prior to building.
+	ForcePull bool `json:"forcePull,omitempty" protobuf:"varint,5,opt,name=forcePull"`
+
+	// dockerfilePath is the path of the Dockerfile that will be used to build the Docker image,
+	// relative to the root of the context (contextDir).
+	DockerfilePath string `json:"dockerfilePath,omitempty" protobuf:"bytes,6,opt,name=dockerfilePath"`
+
+	// buildArgs contains build arguments that will be resolved in the Dockerfile.  See
+	// https://docs.docker.com/engine/reference/builder/#/arg for more details.
+	BuildArgs []kapi.EnvVar `json:"buildArgs,omitempty" protobuf:"bytes,7,rep,name=buildArgs"`
+
+	// imageOptimizationPolicy describes what optimizations the system can use when building images
+	// to reduce the final size or time spent building the image. The default policy is 'None' which
+	// means the final build image will be equivalent to an image created by the Docker build API.
+	// The experimental policy 'SkipLayers' will avoid commiting new layers in between each
+	// image step, and will fail if the Dockerfile cannot provide compatibility with the 'None'
+	// policy. An additional experimental policy 'SkipLayersAndWarn' is the same as
+	// 'SkipLayers' but simply warns if compatibility cannot be preserved.
+	ImageOptimizationPolicy *ImageOptimizationPolicy `json:"imageOptimizationPolicy,omitempty" protobuf:"bytes,8,opt,name=imageOptimizationPolicy,casttype=ImageOptimizationPolicy"`
+}
+
+// SourceBuildStrategy defines input parameters specific to an Source build.
+type SourceBuildStrategy struct {
+	// from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which
+	// the docker image should be pulled
+	From kapi.ObjectReference `json:"from" protobuf:"bytes,1,opt,name=from"`
+
+	// pullSecret is the name of a Secret that would be used for setting up
+	// the authentication for pulling the Docker images from the private Docker
+	// registries
+	PullSecret *kapi.LocalObjectReference `json:"pullSecret,omitempty" protobuf:"bytes,2,opt,name=pullSecret"`
+
+	// env contains additional environment variables you want to pass into a builder container.
+	Env []kapi.EnvVar `json:"env,omitempty" protobuf:"bytes,3,rep,name=env"`
+
+	// scripts is the location of Source scripts
+	Scripts string `json:"scripts,omitempty" protobuf:"bytes,4,opt,name=scripts"`
+
+	// incremental flag forces the Source build to do incremental builds if true.
+	Incremental *bool `json:"incremental,omitempty" protobuf:"varint,5,opt,name=incremental"`
+
+	// forcePull describes if the builder should pull the images from registry prior to building.
+	ForcePull bool `json:"forcePull,omitempty" protobuf:"varint,6,opt,name=forcePull"`
+
+	// runtimeImage is an optional image that is used to run an application
+	// without unneeded dependencies installed. The building of the application
+	// is still done in the builder image but, post build, you can copy the
+	// needed artifacts in the runtime image for use.
+	// Deprecated: This feature will be removed in a future release. Use ImageSource
+	// to copy binary artifacts created from one build into a separate runtime image.
+	RuntimeImage *kapi.ObjectReference `json:"runtimeImage,omitempty" protobuf:"bytes,7,opt,name=runtimeImage"`
+
+	// runtimeArtifacts specifies a list of source/destination pairs that will be
+	// copied from the builder to the runtime image. sourcePath can be a file or
+	// directory. destinationDir must be a directory. destinationDir can also be
+	// empty or equal to ".", in this case it just refers to the root of WORKDIR.
+	// Deprecated: This feature will be removed in a future release. Use ImageSource
+	// to copy binary artifacts created from one build into a separate runtime image.
+	RuntimeArtifacts []ImageSourcePath `json:"runtimeArtifacts,omitempty" protobuf:"bytes,8,rep,name=runtimeArtifacts"`
+}
+
+// JenkinsPipelineBuildStrategy holds parameters specific to a Jenkins Pipeline build.
+// This strategy is in tech preview.
+type JenkinsPipelineBuildStrategy struct {
+	// JenkinsfilePath is the optional path of the Jenkinsfile that will be used to configure the pipeline
+	// relative to the root of the context (contextDir). If both JenkinsfilePath & Jenkinsfile are
+	// both not specified, this defaults to Jenkinsfile in the root of the specified contextDir.
+	JenkinsfilePath string `json:"jenkinsfilePath,omitempty" protobuf:"bytes,1,opt,name=jenkinsfilePath"`
+
+	// Jenkinsfile defines the optional raw contents of a Jenkinsfile which defines a Jenkins pipeline build.
+	Jenkinsfile string `json:"jenkinsfile,omitempty" protobuf:"bytes,2,opt,name=jenkinsfile"`
+
+	// env contains additional environment variables you want to pass into a build pipeline.
+	Env []kapi.EnvVar `json:"env,omitempty" protobuf:"bytes,3,rep,name=env"`
+}
+
+// A BuildPostCommitSpec holds a build post commit hook specification. The hook
+// executes a command in a temporary container running the build output image,
+// immediately after the last layer of the image is committed and before the
+// image is pushed to a registry. The command is executed with the current
+// working directory ($PWD) set to the image's WORKDIR.
+//
+// The build will be marked as failed if the hook execution fails. It will fail
+// if the script or command return a non-zero exit code, or if there is any
+// other error related to starting the temporary container.
+//
+// There are five different ways to configure the hook. As an example, all forms
+// below are equivalent and will execute `rake test --verbose`.
+//
+// 1. Shell script:
+//
+//        "postCommit": {
+//          "script": "rake test --verbose",
+//        }
+//
+//     The above is a convenient form which is equivalent to:
+//
+//        "postCommit": {
+//          "command": ["/bin/sh", "-ic"],
+//          "args":    ["rake test --verbose"]
+//        }
+//
+// 2. A command as the image entrypoint:
+//
+//        "postCommit": {
+//          "commit": ["rake", "test", "--verbose"]
+//        }
+//
+//     Command overrides the image entrypoint in the exec form, as documented in
+//     Docker: https://docs.docker.com/engine/reference/builder/#entrypoint.
+//
+// 3. Pass arguments to the default entrypoint:
+//
+//        "postCommit": {
+// 		      "args": ["rake", "test", "--verbose"]
+// 	      }
+//
+//     This form is only useful if the image entrypoint can handle arguments.
+//
+// 4. Shell script with arguments:
+//
+//        "postCommit": {
+//          "script": "rake test $1",
+//          "args":   ["--verbose"]
+//        }
+//
+//     This form is useful if you need to pass arguments that would otherwise be
+//     hard to quote properly in the shell script. In the script, $0 will be
+//     "/bin/sh" and $1, $2, etc, are the positional arguments from Args.
+//
+// 5. Command with arguments:
+//
+//        "postCommit": {
+//          "command": ["rake", "test"],
+//          "args":    ["--verbose"]
+//        }
+//
+//     This form is equivalent to appending the arguments to the Command slice.
+//
+// It is invalid to provide both Script and Command simultaneously. If none of
+// the fields are specified, the hook is not executed.
+type BuildPostCommitSpec struct {
+	// command is the command to run. It may not be specified with Script.
+	// This might be needed if the image doesn't have `/bin/sh`, or if you
+	// do not want to use a shell. In all other cases, using Script might be
+	// more convenient.
+	Command []string `json:"command,omitempty" protobuf:"bytes,1,rep,name=command"`
+	// args is a list of arguments that are provided to either Command,
+	// Script or the Docker image's default entrypoint. The arguments are
+	// placed immediately after the command to be run.
+	Args []string `json:"args,omitempty" protobuf:"bytes,2,rep,name=args"`
+	// script is a shell script to be run with `/bin/sh -ic`. It may not be
+	// specified with Command. Use Script when a shell script is appropriate
+	// to execute the post build hook, for example for running unit tests
+	// with `rake test`. If you need control over the image entrypoint, or
+	// if the image does not have `/bin/sh`, use Command and/or Args.
+	// The `-i` flag is needed to support CentOS and RHEL images that use
+	// Software Collections (SCL), in order to have the appropriate
+	// collections enabled in the shell. E.g., in the Ruby image, this is
+	// necessary to make `ruby`, `bundle` and other binaries available in
+	// the PATH.
+	Script string `json:"script,omitempty" protobuf:"bytes,3,opt,name=script"`
+}
+
+// BuildOutput is input to a build strategy and describes the Docker image that the strategy
+// should produce.
+type BuildOutput struct {
+	// to defines an optional location to push the output of this build to.
+	// Kind must be one of 'ImageStreamTag' or 'DockerImage'.
+	// This value will be used to look up a Docker image repository to push to.
+	// In the case of an ImageStreamTag, the ImageStreamTag will be looked for in the namespace of
+	// the build unless Namespace is specified.
+	To *kapi.ObjectReference `json:"to,omitempty" protobuf:"bytes,1,opt,name=to"`
+
+	// PushSecret is the name of a Secret that would be used for setting
+	// up the authentication for executing the Docker push to authentication
+	// enabled Docker Registry (or Docker Hub).
+	PushSecret *kapi.LocalObjectReference `json:"pushSecret,omitempty" protobuf:"bytes,2,opt,name=pushSecret"`
+
+	// imageLabels define a list of labels that are applied to the resulting image. If there
+	// are multiple labels with the same name then the last one in the list is used.
+	ImageLabels []ImageLabel `json:"imageLabels,omitempty" protobuf:"bytes,3,rep,name=imageLabels"`
+}
+
+// ImageLabel represents a label applied to the resulting image.
+type ImageLabel struct {
+	// name defines the name of the label. It must have non-zero length.
+	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
+
+	// value defines the literal value of the label.
+	Value string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
+}
+
+// +genclient
+// +genclient:method=Instantiate,verb=create,subresource=instantiate,input=BuildRequest,result=Build
+// +genclient:method=InstantiateBinary,verb=create,subresource=instantiateBinary,input=BinaryBuildRequestOptions,result=Build
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// Build configurations define a build process for new Docker images. There are three types of builds possible - a Docker build using a Dockerfile, a Source-to-Image build that uses a specially prepared base image that accepts source code that it can make runnable, and a custom build that can run // arbitrary Docker images as a base and accept the build parameters. Builds run on the cluster and on completion are pushed to the Docker registry specified in the "output" section. A build can be triggered via a webhook, when the base image changes, or when a user manually requests a new build be // created.
+//
+// Each build created by a build configuration is numbered and refers back to its parent configuration. Multiple builds can be triggered at once. Builds that do not have "output" set can be used to test code or run a verification build.
+type BuildConfig struct {
+	metav1.TypeMeta `json:",inline"`
+	// metadata for BuildConfig.
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// spec holds all the input necessary to produce a new build, and the conditions when
+	// to trigger them.
+	Spec BuildConfigSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
+	// status holds any relevant information about a build config
+	Status BuildConfigStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
+}
+
+// BuildConfigSpec describes when and how builds are created
+type BuildConfigSpec struct {
+
+	//triggers determine how new Builds can be launched from a BuildConfig. If
+	//no triggers are defined, a new build can only occur as a result of an
+	//explicit client build creation.
+	Triggers []BuildTriggerPolicy `json:"triggers" protobuf:"bytes,1,rep,name=triggers"`
+
+	// RunPolicy describes how the new build created from this build
+	// configuration will be scheduled for execution.
+	// This is optional, if not specified we default to "Serial".
+	RunPolicy BuildRunPolicy `json:"runPolicy,omitempty" protobuf:"bytes,2,opt,name=runPolicy,casttype=BuildRunPolicy"`
+
+	// CommonSpec is the desired build specification
+	CommonSpec `json:",inline" protobuf:"bytes,3,opt,name=commonSpec"`
+
+	// successfulBuildsHistoryLimit is the number of old successful builds to retain.
+	// If not specified, all successful builds are retained.
+	SuccessfulBuildsHistoryLimit *int32 `json:"successfulBuildsHistoryLimit,omitempty" protobuf:"varint,4,opt,name=successfulBuildsHistoryLimit"`
+
+	// failedBuildsHistoryLimit is the number of old failed builds to retain.
+	// If not specified, all failed builds are retained.
+	FailedBuildsHistoryLimit *int32 `json:"failedBuildsHistoryLimit,omitempty" protobuf:"varint,5,opt,name=failedBuildsHistoryLimit"`
+}
+
+// BuildRunPolicy defines the behaviour of how the new builds are executed
+// from the existing build configuration.
+type BuildRunPolicy string
+
+const (
+	// BuildRunPolicyParallel schedules new builds immediately after they are
+	// created. Builds will be executed in parallel.
+	BuildRunPolicyParallel BuildRunPolicy = "Parallel"
+
+	// BuildRunPolicySerial schedules new builds to execute in a sequence as
+	// they are created. Every build gets queued up and will execute when the
+	// previous build completes. This is the default policy.
+	BuildRunPolicySerial BuildRunPolicy = "Serial"
+
+	// BuildRunPolicySerialLatestOnly schedules only the latest build to execute,
+	// cancelling all the previously queued build.
+	BuildRunPolicySerialLatestOnly BuildRunPolicy = "SerialLatestOnly"
+)
+
+// BuildConfigStatus contains current state of the build config object.
+type BuildConfigStatus struct {
+	// lastVersion is used to inform about number of last triggered build.
+	LastVersion int64 `json:"lastVersion" protobuf:"varint,1,opt,name=lastVersion"`
+}
+
+// WebHookTrigger is a trigger that gets invoked using a webhook type of post
+type WebHookTrigger struct {
+	// secret used to validate requests.
+	Secret string `json:"secret,omitempty" protobuf:"bytes,1,opt,name=secret"`
+
+	// allowEnv determines whether the webhook can set environment variables; can only
+	// be set to true for GenericWebHook.
+	AllowEnv bool `json:"allowEnv,omitempty" protobuf:"varint,2,opt,name=allowEnv"`
+}
+
+// ImageChangeTrigger allows builds to be triggered when an ImageStream changes
+type ImageChangeTrigger struct {
+	// lastTriggeredImageID is used internally by the ImageChangeController to save last
+	// used image ID for build
+	LastTriggeredImageID string `json:"lastTriggeredImageID,omitempty" protobuf:"bytes,1,opt,name=lastTriggeredImageID"`
+
+	// from is a reference to an ImageStreamTag that will trigger a build when updated
+	// It is optional. If no From is specified, the From image from the build strategy
+	// will be used. Only one ImageChangeTrigger with an empty From reference is allowed in
+	// a build configuration.
+	From *kapi.ObjectReference `json:"from,omitempty" protobuf:"bytes,2,opt,name=from"`
+}
+
+// BuildTriggerPolicy describes a policy for a single trigger that results in a new Build.
+type BuildTriggerPolicy struct {
+	// type is the type of build trigger
+	Type BuildTriggerType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=BuildTriggerType"`
+
+	// github contains the parameters for a GitHub webhook type of trigger
+	GitHubWebHook *WebHookTrigger `json:"github,omitempty" protobuf:"bytes,2,opt,name=github"`
+
+	// generic contains the parameters for a Generic webhook type of trigger
+	GenericWebHook *WebHookTrigger `json:"generic,omitempty" protobuf:"bytes,3,opt,name=generic"`
+
+	// imageChange contains parameters for an ImageChange type of trigger
+	ImageChange *ImageChangeTrigger `json:"imageChange,omitempty" protobuf:"bytes,4,opt,name=imageChange"`
+
+	// GitLabWebHook contains the parameters for a GitLab webhook type of trigger
+	GitLabWebHook *WebHookTrigger `json:"gitlab,omitempty" protobuf:"bytes,5,opt,name=gitlab"`
+
+	// BitbucketWebHook contains the parameters for a Bitbucket webhook type of
+	// trigger
+	BitbucketWebHook *WebHookTrigger `json:"bitbucket,omitempty" protobuf:"bytes,6,opt,name=bitbucket"`
+}
+
+// BuildTriggerType refers to a specific BuildTriggerPolicy implementation.
+type BuildTriggerType string
+
+const (
+	// GitHubWebHookBuildTriggerType represents a trigger that launches builds on
+	// GitHub webhook invocations
+	GitHubWebHookBuildTriggerType           BuildTriggerType = "GitHub"
+	GitHubWebHookBuildTriggerTypeDeprecated BuildTriggerType = "github"
+
+	// GenericWebHookBuildTriggerType represents a trigger that launches builds on
+	// generic webhook invocations
+	GenericWebHookBuildTriggerType           BuildTriggerType = "Generic"
+	GenericWebHookBuildTriggerTypeDeprecated BuildTriggerType = "generic"
+
+	// GitLabWebHookBuildTriggerType represents a trigger that launches builds on
+	// GitLab webhook invocations
+	GitLabWebHookBuildTriggerType BuildTriggerType = "GitLab"
+
+	// BitbucketWebHookBuildTriggerType represents a trigger that launches builds on
+	// Bitbucket webhook invocations
+	BitbucketWebHookBuildTriggerType BuildTriggerType = "Bitbucket"
+
+	// ImageChangeBuildTriggerType represents a trigger that launches builds on
+	// availability of a new version of an image
+	ImageChangeBuildTriggerType           BuildTriggerType = "ImageChange"
+	ImageChangeBuildTriggerTypeDeprecated BuildTriggerType = "imageChange"
+
+	// ConfigChangeBuildTriggerType will trigger a build on an initial build config creation
+	// WARNING: In the future the behavior will change to trigger a build on any config change
+	ConfigChangeBuildTriggerType BuildTriggerType = "ConfigChange"
+)
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// BuildList is a collection of Builds.
+type BuildList struct {
+	metav1.TypeMeta `json:",inline"`
+	// metadata for BuildList.
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// items is a list of builds
+	Items []Build `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// BuildConfigList is a collection of BuildConfigs.
+type BuildConfigList struct {
+	metav1.TypeMeta `json:",inline"`
+	// metadata for BuildConfigList.
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// items is a list of build configs
+	Items []BuildConfig `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+// GenericWebHookEvent is the payload expected for a generic webhook post
+type GenericWebHookEvent struct {
+	// type is the type of source repository
+	// +k8s:conversion-gen=false
+	Type BuildSourceType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type,casttype=BuildSourceType"`
+
+	// git is the git information if the Type is BuildSourceGit
+	Git *GitInfo `json:"git,omitempty" protobuf:"bytes,2,opt,name=git"`
+
+	// env contains additional environment variables you want to pass into a builder container.
+	// ValueFrom is not supported.
+	Env []kapi.EnvVar `json:"env,omitempty" protobuf:"bytes,3,rep,name=env"`
+
+	// DockerStrategyOptions contains additional docker-strategy specific options for the build
+	DockerStrategyOptions *DockerStrategyOptions `json:"dockerStrategyOptions,omitempty" protobuf:"bytes,4,opt,name=dockerStrategyOptions"`
+}
+
+// GitInfo is the aggregated git information for a generic webhook post
+type GitInfo struct {
+	GitBuildSource    `json:",inline" protobuf:"bytes,1,opt,name=gitBuildSource"`
+	GitSourceRevision `json:",inline" protobuf:"bytes,2,opt,name=gitSourceRevision"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// BuildLog is the (unused) resource associated with the build log redirector
+type BuildLog struct {
+	metav1.TypeMeta `json:",inline"`
+}
+
+// DockerStrategyOptions contains extra strategy options for Docker builds
+type DockerStrategyOptions struct {
+	// Args contains any build arguments that are to be passed to Docker.  See
+	// https://docs.docker.com/engine/reference/builder/#/arg for more details
+	BuildArgs []kapi.EnvVar `json:"buildArgs,omitempty" protobuf:"bytes,1,rep,name=buildArgs"`
+
+	// noCache overrides the docker-strategy noCache option in the build config
+	NoCache *bool `json:"noCache,omitempty" protobuf:"varint,2,opt,name=noCache"`
+}
+
+// SourceStrategyOptions contains extra strategy options for Source builds
+type SourceStrategyOptions struct {
+	// incremental overrides the source-strategy incremental option in the build config
+	Incremental *bool `json:"incremental,omitempty" protobuf:"varint,1,opt,name=incremental"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// BuildRequest is the resource used to pass parameters to build generator
+type BuildRequest struct {
+	metav1.TypeMeta `json:",inline"`
+	// metadata for BuildRequest.
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// revision is the information from the source for a specific repo snapshot.
+	Revision *SourceRevision `json:"revision,omitempty" protobuf:"bytes,2,opt,name=revision"`
+
+	// triggeredByImage is the Image that triggered this build.
+	TriggeredByImage *kapi.ObjectReference `json:"triggeredByImage,omitempty" protobuf:"bytes,3,opt,name=triggeredByImage"`
+
+	// from is the reference to the ImageStreamTag that triggered the build.
+	From *kapi.ObjectReference `json:"from,omitempty" protobuf:"bytes,4,opt,name=from"`
+
+	// binary indicates a request to build from a binary provided to the builder
+	Binary *BinaryBuildSource `json:"binary,omitempty" protobuf:"bytes,5,opt,name=binary"`
+
+	// lastVersion (optional) is the LastVersion of the BuildConfig that was used
+	// to generate the build. If the BuildConfig in the generator doesn't match, a build will
+	// not be generated.
+	LastVersion *int64 `json:"lastVersion,omitempty" protobuf:"varint,6,opt,name=lastVersion"`
+
+	// env contains additional environment variables you want to pass into a builder container.
+	Env []kapi.EnvVar `json:"env,omitempty" protobuf:"bytes,7,rep,name=env"`
+
+	// triggeredBy describes which triggers started the most recent update to the
+	// build configuration and contains information about those triggers.
+	TriggeredBy []BuildTriggerCause `json:"triggeredBy" protobuf:"bytes,8,rep,name=triggeredBy"`
+
+	// DockerStrategyOptions contains additional docker-strategy specific options for the build
+	DockerStrategyOptions *DockerStrategyOptions `json:"dockerStrategyOptions,omitempty" protobuf:"bytes,9,opt,name=dockerStrategyOptions"`
+
+	// SourceStrategyOptions contains additional source-strategy specific options for the build
+	SourceStrategyOptions *SourceStrategyOptions `json:"sourceStrategyOptions,omitempty" protobuf:"bytes,10,opt,name=sourceStrategyOptions"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// BinaryBuildRequestOptions are the options required to fully speficy a binary build request
+type BinaryBuildRequestOptions struct {
+	metav1.TypeMeta `json:",inline"`
+	// metadata for BinaryBuildRequestOptions.
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// asFile determines if the binary should be created as a file within the source rather than extracted as an archive
+	AsFile string `json:"asFile,omitempty" protobuf:"bytes,2,opt,name=asFile"`
+
+	// TODO: Improve map[string][]string conversion so we can handled nested objects
+
+	// revision.commit is the value identifying a specific commit
+	Commit string `json:"revision.commit,omitempty" protobuf:"bytes,3,opt,name=revisionCommit"`
+
+	// revision.message is the description of a specific commit
+	Message string `json:"revision.message,omitempty" protobuf:"bytes,4,opt,name=revisionMessage"`
+
+	// revision.authorName of the source control user
+	AuthorName string `json:"revision.authorName,omitempty" protobuf:"bytes,5,opt,name=revisionAuthorName"`
+
+	// revision.authorEmail of the source control user
+	AuthorEmail string `json:"revision.authorEmail,omitempty" protobuf:"bytes,6,opt,name=revisionAuthorEmail"`
+
+	// revision.committerName of the source control user
+	CommitterName string `json:"revision.committerName,omitempty" protobuf:"bytes,7,opt,name=revisionCommitterName"`
+
+	// revision.committerEmail of the source control user
+	CommitterEmail string `json:"revision.committerEmail,omitempty" protobuf:"bytes,8,opt,name=revisionCommitterEmail"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// BuildLogOptions is the REST options for a build log
+type BuildLogOptions struct {
+	metav1.TypeMeta `json:",inline"`
+
+	// cointainer for which to stream logs. Defaults to only container if there is one container in the pod.
+	Container string `json:"container,omitempty" protobuf:"bytes,1,opt,name=container"`
+	// follow if true indicates that the build log should be streamed until
+	// the build terminates.
+	Follow bool `json:"follow,omitempty" protobuf:"varint,2,opt,name=follow"`
+	// previous returns previous build logs. Defaults to false.
+	Previous bool `json:"previous,omitempty" protobuf:"varint,3,opt,name=previous"`
+	// sinceSeconds is a relative time in seconds before the current time from which to show logs. If this value
+	// precedes the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceSeconds *int64 `json:"sinceSeconds,omitempty" protobuf:"varint,4,opt,name=sinceSeconds"`
+	// sinceTime is an RFC3339 timestamp from which to show logs. If this value
+	// precedes the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceTime *metav1.Time `json:"sinceTime,omitempty" protobuf:"bytes,5,opt,name=sinceTime"`
+	// timestamps, If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+	// of log output. Defaults to false.
+	Timestamps bool `json:"timestamps,omitempty" protobuf:"varint,6,opt,name=timestamps"`
+	// tailLines, If set, is the number of lines from the end of the logs to show. If not specified,
+	// logs are shown from the creation of the container or sinceSeconds or sinceTime
+	TailLines *int64 `json:"tailLines,omitempty" protobuf:"varint,7,opt,name=tailLines"`
+	// limitBytes, If set, is the number of bytes to read from the server before terminating the
+	// log output. This may not display a complete final line of logging, and may return
+	// slightly more or slightly less than the specified limit.
+	LimitBytes *int64 `json:"limitBytes,omitempty" protobuf:"varint,8,opt,name=limitBytes"`
+
+	// noWait if true causes the call to return immediately even if the build
+	// is not available yet. Otherwise the server will wait until the build has started.
+	// TODO: Fix the tag to 'noWait' in v2
+	NoWait bool `json:"nowait,omitempty" protobuf:"varint,9,opt,name=nowait"`
+
+	// version of the build for which to view logs.
+	Version *int64 `json:"version,omitempty" protobuf:"varint,10,opt,name=version"`
+}
+
+// SecretSpec specifies a secret to be included in a build pod and its corresponding mount point
+type SecretSpec struct {
+	// secretSource is a reference to the secret
+	SecretSource kapi.LocalObjectReference `json:"secretSource" protobuf:"bytes,1,opt,name=secretSource"`
+
+	// mountPath is the path at which to mount the secret
+	MountPath string `json:"mountPath" protobuf:"bytes,2,opt,name=mountPath"`
+}

--- a/pkg/openshift/client/builds.go
+++ b/pkg/openshift/client/builds.go
@@ -1,0 +1,56 @@
+/**
+
+The build package has the same signature as the openshift client library so hopefully will reduce the pain when moving over to the official client.
+
+
+*/
+
+package client
+
+import (
+	"encoding/json"
+
+	"bytes"
+	"fmt"
+	"net/http"
+
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/build"
+	"github.com/pkg/errors"
+)
+
+type BuildConfigs struct {
+	ns          string
+	host, token string
+	restClient  *http.Client
+}
+
+const (
+	buildconfigURL = "%s/oapi/v1/namespaces/%s/buildconfigs"
+)
+
+func (bc *BuildConfigs) Create(config *build.BuildConfig) (*build.BuildConfig, error) {
+	payload, err := json.Marshal(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal buildconfig payload")
+	}
+	u := fmt.Sprintf(buildconfigURL, bc.host, bc.ns)
+	req, err := http.NewRequest("POST", u, bytes.NewReader(payload))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to prepare post request for buildconfig create")
+	}
+	req.Header.Set("Authorization", "Bearer "+bc.token)
+	req.Header.Set("Content-type", "application/json")
+	res, err := bc.restClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to make request to create buildconfig ")
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusCreated {
+		return nil, errors.Wrap(err, "unexpected status creating buildconfig")
+	}
+	return config, nil
+}
+
+func (bd *BuildConfigs) Update(config *build.BuildConfig) (*build.BuildConfig, error) {
+	return nil, nil
+}

--- a/pkg/openshift/client/client.go
+++ b/pkg/openshift/client/client.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"net/http"
+
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/build"
+)
+
+type Client struct {
+	ns          string
+	host, token string
+	restClient  *http.Client
+}
+
+func NewClient(ns, host, token string, httpClient *http.Client) *Client {
+	return &Client{
+		ns:         ns,
+		host:       host,
+		token:      token,
+		restClient: httpClient,
+	}
+}
+
+// Builds provides a REST client for Builds
+func (c *Client) Builds(namespace string) BuildInterface {
+	return &BuildConfigs{ns: namespace, host: c.host, token: c.token, restClient: c.restClient}
+}
+
+// BuildConfigs provides a REST client for BuildConfigs
+func (c *Client) BuildConfigs(namespace string) BuildConfigInterface {
+	return &BuildConfigs{ns: namespace, host: c.host, token: c.token, restClient: c.restClient}
+}
+
+// Interface exposes methods on OpenShift resources.
+type Interface interface {
+	BuildsNamespacer
+	BuildConfigsNamespacer
+}
+
+type BuildsNamespacer interface {
+	Builds(namespace string) BuildInterface
+}
+
+type BuildConfigsNamespacer interface {
+	BuildConfigs(namespace string) BuildConfigInterface
+}
+
+type BuildInterface interface{}
+
+type BuildConfigInterface interface {
+	Create(config *build.BuildConfig) (*build.BuildConfig, error)
+	Update(config *build.BuildConfig) (*build.BuildConfig, error)
+}

--- a/pkg/openshift/clientBuilder.go
+++ b/pkg/openshift/clientBuilder.go
@@ -1,0 +1,74 @@
+package openshift
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"github.com/feedhenry/mcp-standalone/pkg/mobile"
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/client"
+)
+
+//ClientBuilder is a utility to help in the construction of OpenShift clients
+type ClientBuilder struct {
+	token, host, ns string
+	incluster       bool
+	insecure        bool
+}
+
+func NewClientBuilder(host, ns string, incluster, insecure bool) mobile.OSClientBuilder {
+	cb := &ClientBuilder{
+		host:      host,
+		ns:        ns,
+		incluster: incluster,
+		insecure:  insecure,
+	}
+	return cb
+
+}
+
+func (cb *ClientBuilder) WithToken(token string) mobile.OSClientBuilder {
+	return &ClientBuilder{
+		host:      cb.host,
+		token:     token,
+		ns:        cb.ns,
+		incluster: cb.incluster,
+		insecure:  cb.insecure,
+	}
+}
+func (cb *ClientBuilder) WithNamespace(ns string) mobile.OSClientBuilder {
+	return &ClientBuilder{
+		host:      cb.host,
+		token:     cb.token,
+		ns:        ns,
+		incluster: cb.incluster,
+	}
+}
+func (cb *ClientBuilder) WithHost(host string) mobile.OSClientBuilder {
+	return &ClientBuilder{
+		host:      host,
+		token:     cb.token,
+		ns:        cb.ns,
+		incluster: cb.incluster,
+		insecure:  cb.insecure,
+	}
+}
+func (cb *ClientBuilder) WithHostAndNamespace(host, ns string) mobile.OSClientBuilder {
+	return &ClientBuilder{
+		host:      host,
+		token:     cb.token,
+		ns:        ns,
+		incluster: cb.incluster,
+		insecure:  cb.insecure,
+	}
+}
+func (cb *ClientBuilder) BuildClient() (client.Interface, error) {
+	//using own http client here as it will be replaced by the oc client once 3.8 arrives
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: cb.insecure},
+	}
+	httpClient := &http.Client{Transport: tr}
+	httpClient.Timeout = 30 * time.Second
+	return client.NewClient(cb.ns, cb.host, cb.token, httpClient), nil
+}

--- a/pkg/openshift/testclient/client.go
+++ b/pkg/openshift/testclient/client.go
@@ -1,0 +1,31 @@
+package testclient
+
+import (
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/client"
+	"k8s.io/client-go/testing"
+)
+
+type Client struct {
+	ns          string
+	host, token string
+	Fake        *testing.Fake
+}
+
+func NewClient(ns, host, token string, fake *testing.Fake) *Client {
+	return &Client{
+		ns:    ns,
+		host:  host,
+		token: token,
+		Fake:  fake,
+	}
+}
+
+// Builds provides a REST client for Builds
+func (c *Client) Builds(namespace string) client.BuildInterface {
+	return NewFakeBuildConfigs(namespace, c.Fake)
+}
+
+// BuildConfigs provides a REST client for BuildConfigs
+func (c *Client) BuildConfigs(namespace string) client.BuildConfigInterface {
+	return NewFakeBuildConfigs(namespace, c.Fake)
+}

--- a/pkg/openshift/testclient/fakebuildconfigs.go
+++ b/pkg/openshift/testclient/fakebuildconfigs.go
@@ -1,0 +1,44 @@
+package testclient
+
+import (
+	"github.com/feedhenry/mcp-standalone/pkg/openshift/build"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/testing"
+)
+
+var buildConfigsResource = schema.GroupVersionResource{Group: "", Version: "", Resource: "buildconfigs"}
+var buildConfigsKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "BuildConfig"}
+
+// FakeBuildConfigs implements BuildConfigInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeBuildConfigs struct {
+	Fake      *testing.Fake
+	Namespace string
+}
+
+func NewFakeBuildConfigs(ns string, fake *testing.Fake) *FakeBuildConfigs {
+	fb := &FakeBuildConfigs{
+		Namespace: ns,
+		Fake:      fake,
+	}
+	if fb.Fake == nil {
+		fb.Fake = &testing.Fake{}
+	}
+	return fb
+}
+
+func (c *FakeBuildConfigs) Create(config *build.BuildConfig) (*build.BuildConfig, error) {
+	bc, err := c.Fake.Invokes(testing.NewCreateAction(buildConfigsResource, c.Namespace, config), config)
+	if nil != bc {
+		return bc.(*build.BuildConfig), err
+	}
+	return nil, err
+}
+
+func (c *FakeBuildConfigs) Update(config *build.BuildConfig) (*build.BuildConfig, error) {
+	bc, err := c.Fake.Invokes(testing.NewUpdateAction(buildConfigsResource, c.Namespace, config), config)
+	if nil != bc {
+		return bc.(*build.BuildConfig), err
+	}
+	return nil, err
+}

--- a/pkg/web/middleware/access.go
+++ b/pkg/web/middleware/access.go
@@ -51,7 +51,6 @@ var ingnoreList = buildIgnoreList()
 func shouldIgnore(path string) bool {
 	for _, i := range ingnoreList {
 		if i.Match([]byte(path)) {
-			fmt.Println("ignoring user access check on path: ", path)
 			return true
 		}
 	}

--- a/pkg/web/mobileBuildHandler_test.go
+++ b/pkg/web/mobileBuildHandler_test.go
@@ -1,0 +1,130 @@
+package web_test
+
+import (
+	"net/http"
+	"testing"
+
+	"net/http/httptest"
+
+	"bytes"
+	"encoding/json"
+
+	"io/ioutil"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/feedhenry/mcp-standalone/pkg/data"
+	"github.com/feedhenry/mcp-standalone/pkg/mobile"
+	"github.com/feedhenry/mcp-standalone/pkg/mobile/app"
+	"github.com/feedhenry/mcp-standalone/pkg/mock"
+	"github.com/feedhenry/mcp-standalone/pkg/web"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	kfake "k8s.io/client-go/testing"
+)
+
+func setupMobileBuildHandler(kclient kubernetes.Interface, ocFake *kfake.Fake) http.Handler {
+	r := web.NewRouter()
+	logger := logrus.StandardLogger()
+	if nil == kclient {
+		kclient = &fake.Clientset{}
+	}
+
+	cb := &mock.ClientBuilder{
+		Fakeclient: kclient,
+	}
+	ocClientBuilder := mock.NewOCClientBuilder("test", "test", "https://notthere.com", ocFake)
+	repoBuilder := data.NewBuildsRepoBuilder(cb, ocClientBuilder, "test", "test")
+	buildService := app.NewBuild()
+	handler := web.NewBuildHandler(repoBuilder, buildService, logger)
+	web.MobileBuildRoute(r, handler)
+	return web.BuildHTTPHandler(r, nil)
+}
+
+func TestBuildHandler_Create(t *testing.T) {
+	cases := []struct {
+		Name        string
+		K8Client    func() kubernetes.Interface
+		OCClient    func() *kfake.Fake
+		ExpectError bool
+		StatusCode  int
+		MobileBuild *mobile.Build
+		Validate    func(t *testing.T, ar *app.AppBuildCreatedResponse)
+	}{
+		{
+			Name:       "test build create for private repo ok",
+			StatusCode: 201,
+			K8Client: func() kubernetes.Interface {
+				c := &fake.Clientset{}
+				c.AddReactor("create", "secrets", func(action kfake.Action) (handled bool, ret runtime.Object, err error) {
+					obj := action.(kfake.CreateAction).GetObject()
+					return true, obj, nil
+				})
+				return c
+			},
+			OCClient: func() *kfake.Fake {
+
+				c := &kfake.Fake{}
+				c.AddReactor("create", "buildconfig", func(action kfake.Action) (handled bool, ret runtime.Object, err error) {
+					obj := action.(kfake.CreateAction).GetObject()
+					return true, obj, nil
+				})
+				return c
+			},
+			MobileBuild: &mobile.Build{
+				Name:  "mybuild",
+				AppID: "myapp",
+				GitRepo: &mobile.BuildGitRepo{
+					Private: true,
+					URI:     "git@git.com",
+					Ref:     "master",
+				},
+			},
+			Validate: func(t *testing.T, ar *app.AppBuildCreatedResponse) {
+				if nil == ar {
+					t.Fatal("expected a build creation response but got none")
+				}
+				if ar.PublicKey == "" {
+					t.Fatal("expected a public key in the response but got none")
+				}
+				if ar.BuildID != "mybuild" {
+					t.Fatalf("expected a build id to match : mybuild but got %s", ar.BuildID)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			handler := setupMobileBuildHandler(tc.K8Client(), tc.OCClient())
+			server := httptest.NewServer(handler)
+			defer server.Close()
+			payload, err := json.Marshal(tc.MobileBuild)
+			if err != nil {
+				t.Fatal("failed to marshal json payload")
+			}
+			req, err := http.NewRequest("POST", server.URL+"/build", bytes.NewReader(payload))
+			if err != nil {
+				t.Fatalf("did not expect an error setting up request %s", err)
+			}
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("did not expect an error making request %s", err)
+			}
+			defer res.Body.Close()
+			if res.StatusCode != tc.StatusCode {
+				t.Fatalf("expected status code %v but got %v ", tc.StatusCode, res.StatusCode)
+			}
+			if res.StatusCode == 201 {
+				resBody, err := ioutil.ReadAll(res.Body)
+				if err != nil {
+					t.Fatalf("failed to read the response body %s", err)
+				}
+				response := &app.AppBuildCreatedResponse{}
+				if err := json.Unmarshal(resBody, response); err != nil {
+					t.Fatalf("did not expect an error unmarshalling the response body %s ", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/web/mobileServicesHandler.go
+++ b/pkg/web/mobileServicesHandler.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -88,7 +87,6 @@ func (msh *MobileServiceHandler) Read(rw http.ResponseWriter, req *http.Request)
 	client := httpclient.NewClientBuilder().Insecure(true).Timeout(5).Build()
 
 	if withIntegrations != "" {
-		fmt.Println("with Integrations", serviceName)
 		ms, err = msh.mobileIntegrationService.ReadMobileServiceAndIntegrations(serviceCruder, authChecker, serviceName, client)
 		if err != nil {
 			handleCommonErrorCases(err, rw, msh.logger)

--- a/pkg/web/mobilebuildHandler.go
+++ b/pkg/web/mobilebuildHandler.go
@@ -1,0 +1,64 @@
+package web
+
+import (
+	"net/http"
+
+	"encoding/json"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/feedhenry/mcp-standalone/pkg/mobile"
+	"github.com/feedhenry/mcp-standalone/pkg/mobile/app"
+	"github.com/feedhenry/mcp-standalone/pkg/web/headers"
+	"github.com/pkg/errors"
+)
+
+type BuildHandler struct {
+	buildRepoBuilder mobile.BuildRepoBuilder
+	buildService     *app.Build
+	logger           *logrus.Logger
+}
+
+// NewBuildHandler returns a configured build handler
+func NewBuildHandler(br mobile.BuildRepoBuilder, buildService *app.Build, logger *logrus.Logger) *BuildHandler {
+	return &BuildHandler{
+		buildRepoBuilder: br,
+		buildService:     buildService,
+		logger:           logger,
+	}
+}
+
+// Create will parse the create request and hand it off to app build service
+func (bh *BuildHandler) Create(rw http.ResponseWriter, req *http.Request) {
+	token := headers.DefaultTokenRetriever(req.Header)
+	buildRepo, err := bh.buildRepoBuilder.WithToken(token).Build()
+	if err != nil {
+		err = errors.Wrap(err, "build handler failed to create build repo instance")
+		handleCommonErrorCases(err, rw, bh.logger)
+		return
+	}
+	var (
+		build   = &mobile.Build{}
+		decoder = json.NewDecoder(req.Body)
+		encoder = json.NewEncoder(rw)
+	)
+
+	if err := decoder.Decode(build); err != nil {
+		err = errors.Wrap(err, "build handler failed to decode build payload")
+		handleCommonErrorCases(err, rw, bh.logger)
+		return
+	}
+
+	res, err := bh.buildService.CreateAppBuild(buildRepo, build)
+	if err != nil {
+		err = errors.Wrap(err, "build handler failed to create app build")
+		handleCommonErrorCases(err, rw, bh.logger)
+		return
+	}
+	rw.WriteHeader(http.StatusCreated)
+	if err := encoder.Encode(res); err != nil {
+		err = errors.Wrap(err, "failed to encode the build response")
+		handleCommonErrorCases(err, rw, bh.logger)
+		return
+	}
+
+}

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -80,6 +80,11 @@ func MobileServiceRoute(r *mux.Router, handler *MobileServiceHandler) {
 	r.HandleFunc("/mobileservice/{name}/metrics", prometheus.InstrumentHandlerFunc("mobileservices get metrics", handler.GetMetrics)).Methods("GET")
 }
 
+// MobileBuildRoute sets up the /build route
+func MobileBuildRoute(r *mux.Router, handler *BuildHandler) {
+	r.HandleFunc("/build", prometheus.InstrumentHandlerFunc("build create", handler.Create)).Methods("POST")
+}
+
 //TODO maybe better place to put this
 func handleCommonErrorCases(err error, rw http.ResponseWriter, logger *logrus.Logger) {
 	e := errors.Cause(err)


### PR DESCRIPTION
first pass at this. Instead of bringing in OC at this point which would mean bringing in all of openshift. I have deffered it till 3.8 when I believe they intend on splitting out the client fully from the openshift repo making it much more light weight.

To reduce friction I have implemented a client that should match the interfaces used by the OpenShift client. This will hopefully mean not too much needs to change once the new client is ready.