### PR TITLE
Adding initial Android SDK INSTALLER template

### DIFF
--- a/artifacts/fake-templates/android-sdk.yaml
+++ b/artifacts/fake-templates/android-sdk.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: android-sdk
+  annotations:
+    openshift.io/display-name: Android SDK Installer!
+    description: "Installer to add Android SDK to the Build Farm (Mobile CI/CD). Before downloading the Android SDK Installer, you must agree to the terms and conditions of the Android Software Development Kit License Agreement, https://developer.android.com/studio/terms.html.\n\n"
+    iconClass: fa fa-android
+    tags: JENKINS,ci cd,mobile-service
+    template.openshift.io/long-description: Not sure if we could here _include_ the actual license, in a textbox/textarea.
+    template.openshift.io/provider-display-name: Feedhenry
+    template.openshift.io/documentation-url: https://github.com/aerogear/digger-jenkins
+    template.openshift.io/support-url: https://github.com/aerogear/digger-jenkins
+labels:
+  template: android-sdk
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: android-sdk
+    labels:
+      app: android-sdk
+      template: android-sdk
+  spec:
+    ports:
+    - name: android-sdk
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+    selector:
+      run: android-sdk
+    sessionAffinity: None
+    type: ClusterIP
+parameters:
+  - name: LICENSE_AGREEMENT
+    description: You need to enter YES in order to continue.
+    from: "YES"
+    required: true

--- a/installer/roles/template-service-broker-setup/defaults/main.yml
+++ b/installer/roles/template-service-broker-setup/defaults/main.yml
@@ -6,6 +6,7 @@ openshift_project: openshift
 
 templates:
 - https://raw.githubusercontent.com/feedhenry/fh-sync-server/master/fh-sync-server-DEVELOPMENT.yaml
+- ../artifacts/fake-templates/android-sdk.yaml
 - ../artifacts/fake-templates/build-farm.yaml
 - ../artifacts/fake-templates/push.yaml
 - ../artifacts/fake-templates/remote-debug.yaml


### PR DESCRIPTION
For https://issues.jboss.org/browse/FH-4148

Adding an _initial_ screen, for an Android Installer.

the template currently renders like:

<img src="https://issues.jboss.org/secure/attachment/12425363/Installer_fake_template.png" > 