### PR TITLE
 🐛 use local versions of bower and grunt so that they don't have to be

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This is required to produce the mcp extension files referenced in master-config.
 
 ```
 cd ui
-grunt local
+./node_modules/.bin/grunt local
 ```
 If you see an `ENOSPC` error, you may need to increase the number of files your user can watch by running this command:
 
@@ -145,7 +145,7 @@ If you see an `ENOSPC` error, you may need to increase the number of files your 
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 ```
 
-*NOTE*: Running `grunt local` will *not* run `uglify` (to help with local dev), and *will* include `scripts/config.local.js`. This file is used to point to a local running MCP server rather than the default of looking up a Route names `mcp-standalone` and using that as the MCP server host.
+*NOTE*: Running `./node_modules/.bin/grunt local` will *not* run `uglify` (to help with local dev), and *will* include `scripts/config.local.js`. This file is used to point to a local running MCP server rather than the default of looking up a Route names `mcp-standalone` and using that as the MCP server host.
 
 ### Step 3, Launch Services
 

--- a/installer/roles/mcp-ui-extension-setup/tasks/main.yml
+++ b/installer/roles/mcp-ui-extension-setup/tasks/main.yml
@@ -6,7 +6,7 @@
   changed_when: false
 
 - name: install dist requirements
-  shell: "cd {{ mcp_local_dir }}/ui && npm i && bower install && grunt build"
+  shell: "cd {{ mcp_local_dir }}/ui && npm i && ./node_modules/.bin/bower install && ./node_modules/.bin/grunt build"
 
 
 # TODO: Use Ansible module here, not oc from shell

--- a/ui/install.sh
+++ b/ui/install.sh
@@ -13,7 +13,7 @@ OPENSHIFT_MASTER_CONFIG=$OPENSHIFT_CONFIG_DIR/master/master-config.yaml
 # Enable Extension Development
 sudo chmod 666 $OPENSHIFT_MASTER_CONFIG
 cd $SCRIPT_ABSOLUTE_PATH
-npm i && bower install
+npm i && ./node_modules/.bin/bower install
 node update_master_config.js $OPENSHIFT_MASTER_CONFIG
 sudo chmod 644 $OPENSHIFT_MASTER_CONFIG
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,9 @@
   },
   "devDependencies": {
     "autoprefixer-core": "^5.2.1",
+    "bower": "^1.8.2",
     "grunt": "^0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-concurrent": "^1.0.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.0",


### PR DESCRIPTION
 installed globally

fix for issue #108 and #109 