### PR TITLE
Moar retries for the MCP extension

### DIFF
--- a/installer/roles/mcp-ui-extension-setup/tasks/main.yml
+++ b/installer/roles/mcp-ui-extension-setup/tasks/main.yml
@@ -36,4 +36,4 @@
   changed_when: false
   until: oc_cluster_status.rc == 0
   poll: 5
-  retries: 30
+  retries: 40


### PR DESCRIPTION
On systems w/o any docker image/container, a lot has to be downloaded - I ran into a situation where the 30 tries do not work - increasing to 40