### PR TITLE
accept insecure as flag and set in template params. Add log level too

### DIFF
--- a/cmd/android-apb/roles/provision-android-app/tasks/main.yml
+++ b/cmd/android-apb/roles/provision-android-app/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - name: provision
   shell: | 
-    oc new-app -f /opt/ansible/roles/provision-android-app/templates/template.json -n '{{namespace}}'
+    oc new-app -f /opt/ansible/roles/provision-android-app/templates/template.json -n '{{namespace}}' -p ACCEPT_UNKNOWN_CERTS=true -p LOG_LEVEL=info
   when: mobile_route.stdout == ""
 
 - name: add-role

--- a/cmd/android-apb/roles/provision-android-app/templates/template.json
+++ b/cmd/android-apb/roles/provision-android-app/templates/template.json
@@ -61,7 +61,9 @@
                                 "command": [
                                     "./mcp-api",
                                     "-cert=/etc/tls/tls.crt",
-                                    "-key=/etc/tls/tls.key"
+                                    "-key=/etc/tls/tls.key",
+                                    "-log-level=${LOG_LEVEL}",
+                                    "-insecure=${ACCEPT_UNKNOWN_CERTS}"
                                 ],
                                 "env": [
                                     {
@@ -72,6 +74,14 @@
                                                 "fieldPath": "metadata.namespace"
                                             }
                                         }
+                                    },
+                                    {
+                                        "name":"ACCEPT_UNKNOWN_CERTS",
+                                        "value":"${ACCEPT_UNKNOWN_CERTS}"
+                                    },
+                                    {
+                                        "name":"LOG_LEVEL",
+                                        "value":"${LOG_LEVEL}"
                                     }
                                 ],
                                 "resources": {},
@@ -193,6 +203,15 @@
         }
     ],
     "parameters":[
-
+        {
+            "description":"This flag is passed to the http clients to allow them to accept insecure self signed certs",
+            "name":"ACCEPT_UNKNOWN_CERTS",
+            "value":"false"
+        },
+        {
+            "description":"This flag is passed to the logger to set the log level (info, debug, error)",
+            "name":"LOG_LEVEL",
+            "value":"error"
+        }
     ]
 }

--- a/cmd/cordova-apb/roles/provision-cordova-apb/tasks/main.yml
+++ b/cmd/cordova-apb/roles/provision-cordova-apb/tasks/main.yml
@@ -4,7 +4,12 @@
 
 - name: provision
   shell: | 
-    oc new-app -f /opt/ansible/roles/provision-cordova-apb/templates/template.json -n '{{namespace}}'
+    oc new-app -f /opt/ansible/roles/provision-cordova-apb/templates/template.json -n '{{namespace}}' -p ACCEPT_UNKNOWN_CERTS=true -p LOG_LEVEL=info
+  when: mobile_route.stdout == ""
+  
+- name: add-role
+  shell: |
+    oc policy add-role-to-user edit system:serviceaccount:{{namespace}}:mcp-standalone
   when: mobile_route.stdout == ""
 
 - name: check_exists_again

--- a/cmd/cordova-apb/roles/provision-cordova-apb/templates/template.json
+++ b/cmd/cordova-apb/roles/provision-cordova-apb/templates/template.json
@@ -61,7 +61,9 @@
                                 "command": [
                                     "./mcp-api",
                                     "-cert=/etc/tls/tls.crt",
-                                    "-key=/etc/tls/tls.key"
+                                    "-key=/etc/tls/tls.key",
+                                    "-log-level=${LOG_LEVEL}",
+                                    "-insecure=${ACCEPT_UNKNOWN_CERTS}"
                                 ],
                                 "env": [
                                     {
@@ -72,6 +74,14 @@
                                                 "fieldPath": "metadata.namespace"
                                             }
                                         }
+                                    },
+                                    {
+                                        "name":"ACCEPT_UNKNOWN_CERTS",
+                                        "value":"${ACCEPT_UNKNOWN_CERTS}"
+                                    },
+                                    {
+                                        "name":"LOG_LEVEL",
+                                        "value":"${LOG_LEVEL}"
                                     }
                                 ],
                                 "resources": {},
@@ -193,6 +203,15 @@
         }
     ],
     "parameters":[
-
+        {
+            "description":"This flag is passed to the http clients to allow them to accept insecure self signed certs",
+            "name":"ACCEPT_UNKNOWN_CERTS",
+            "value":"false"
+        },
+        {
+            "description":"This flag is passed to the logger to set the log level (info, debug, error)",
+            "name":"LOG_LEVEL",
+            "value":"error"
+        }
     ]
 }

--- a/cmd/ios-apb/roles/provision-ios-apb/tasks/main.yml
+++ b/cmd/ios-apb/roles/provision-ios-apb/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: provision
   shell: | 
-    oc new-app -f /opt/ansible/roles/provision-ios-apb/templates/template.json -n '{{namespace}}'
+    oc new-app -f /opt/ansible/roles/provision-ios-apb/templates/template.json -n '{{namespace}}' -p ACCEPT_UNKNOWN_CERTS=true -p LOG_LEVEL=info
   when: mobile_route.stdout == ""
 
 - name: add-role

--- a/cmd/ios-apb/roles/provision-ios-apb/templates/template.json
+++ b/cmd/ios-apb/roles/provision-ios-apb/templates/template.json
@@ -61,7 +61,9 @@
                                 "command": [
                                     "./mcp-api",
                                     "-cert=/etc/tls/tls.crt",
-                                    "-key=/etc/tls/tls.key"
+                                    "-key=/etc/tls/tls.key",
+                                    "-log-level=${LOG_LEVEL}",
+                                    "-insecure=${ACCEPT_UNKNOWN_CERTS}"
                                 ],
                                 "env": [
                                     {
@@ -72,6 +74,14 @@
                                                 "fieldPath": "metadata.namespace"
                                             }
                                         }
+                                    },
+                                    {
+                                        "name":"ACCEPT_UNKNOWN_CERTS",
+                                        "value":"${ACCEPT_UNKNOWN_CERTS}"
+                                    },
+                                    {
+                                        "name":"LOG_LEVEL",
+                                        "value":"${LOG_LEVEL}"
                                     }
                                 ],
                                 "resources": {},
@@ -193,6 +203,15 @@
         }
     ],
     "parameters":[
-
+        {
+            "description":"This flag is passed to the http clients to allow them to accept insecure self signed certs",
+            "name":"ACCEPT_UNKNOWN_CERTS",
+            "value":"false"
+        },
+        {
+            "description":"This flag is passed to the logger to set the log level (info, debug, error)",
+            "name":"LOG_LEVEL",
+            "value":"error"
+        }
     ]
 }

--- a/install/openshift/template.json
+++ b/install/openshift/template.json
@@ -61,7 +61,9 @@
                                 "command": [
                                     "./mcp-api",
                                     "-cert=/etc/tls/tls.crt",
-                                    "-key=/etc/tls/tls.key"
+                                    "-key=/etc/tls/tls.key",
+                                    "-log-level=${LOG_LEVEL}",
+                                    "-insecure=${ACCEPT_UNKNOWN_CERTS}"
                                 ],
                                 "env": [
                                     {
@@ -72,6 +74,14 @@
                                                 "fieldPath": "metadata.namespace"
                                             }
                                         }
+                                    },
+                                    {
+                                        "name":"ACCEPT_UNKNOWN_CERTS",
+                                        "value":"${ACCEPT_UNKNOWN_CERTS}"
+                                    },
+                                    {
+                                        "name":"LOG_LEVEL",
+                                        "value":"${LOG_LEVEL}"
                                     }
                                 ],
                                 "resources": {},
@@ -193,6 +203,15 @@
         }
     ],
     "parameters":[
-
+        {
+            "description":"This flag is passed to the http clients to allow them to accept insecure self signed certs",
+            "name":"ACCEPT_UNKNOWN_CERTS",
+            "value":"false"
+        },
+        {
+            "description":"This flag is passed to the logger to set the log level (info, debug, error)",
+            "name":"LOG_LEVEL",
+            "value":"error"
+        }
     ]
 }


### PR DESCRIPTION
#Adds a param for setting the http clients to accept insecure certs and for setting the log level. Allows the docker image to accept these values at start up time via an env var