### PR TITLE
Only show Build History tab if a Build Config was created

### DIFF
--- a/ui/public/views/mobileapp.html
+++ b/ui/public/views/mobileapp.html
@@ -243,23 +243,28 @@ mobileCore.configure(mcpConfig).then((config) => {
 
                 </uib-tab>
 
-                <uib-tab active="selectedTab.buildHistory" select="setView(buildConfig ? 'view' : 'create')">
+                <uib-tab ng-if="buildConfig && hasBuildFarm" active="selectedTab.buildHistory" select="setView(buildConfig ? 'view' : 'create')">
                   <uib-tab-heading>Build History</uib-tab-heading>
-                  <div class="config-actions clearfix">
-                    <div ng-if="buildConfig && hasBuildFarm"  class="pull-right">
-                      <!-- ng-if="'buildconfigs/instantiate' | canI : 'create'"  -->
-                      <button ng-disabled="view === 'edit'" type="button" class="btn btn-default" ng-click="startBuild()">Build App</button>
-                      <action-dropdown actions=dropdownActions selected=setView></action-dropdown>
-                    </div>
+                  <div ng-if="loading">
+                    Loading...
                   </div>
-                  <div class="row">
-                    <div class="col-lg-12 build-trend">
-                      <build-trends-chart builds=builds></build-trends-chart>
+                  <div ng-if="!loading">
+                    <div class="config-actions clearfix">
+                      <div ng-if="buildConfig && hasBuildFarm"  class="pull-right">
+                        <!-- ng-if="'buildconfigs/instantiate' | canI : 'create'"  -->
+                        <button ng-disabled="view === 'edit'" type="button" class="btn btn-default" ng-click="startBuild()">Build App</button>
+                        <action-dropdown actions=dropdownActions selected=setView></action-dropdown>
+                      </div>
                     </div>
-                  </div>
-                  <div class="row">
-                    <div class="col-lg-12">
-                      <build-pipeline ng-repeat="build in orderedBuilds" build=build></build-pipeline>
+                    <div class="row">
+                      <div class="col-lg-12 build-trend">
+                        <build-trends-chart builds=builds></build-trends-chart>
+                      </div>
+                    </div>
+                    <div class="row">
+                      <div class="col-lg-12">
+                        <build-pipeline ng-repeat="build in orderedBuilds" build=build></build-pipeline>
+                      </div>
                     </div>
                   </div>
                 </uib-tab>


### PR DESCRIPTION
A small change to the App tabs to only show the 'Build History' tab if a Build Config has been created.
This should avoid any confusion about why the 'Build History' tab is completely empty (e.g. is it meant to be empty or is it broken?)

@sedroche could you take a look?
I would see this as a quick ux tweak, while an improvement on this could be to show the Build History tab always and give some help on the screen to get users started with Builds

No Build Config
![image](https://user-images.githubusercontent.com/878251/31338762-8249c7d8-acf8-11e7-9db3-8933eb064a9f.png)

Yes Build Config
![image](https://user-images.githubusercontent.com/878251/31338802-a3f7e13a-acf8-11e7-9f8e-d318d1e3842a.png)
