### PR TITLE
use origin v3.6.0 instead of v3.6.0-rc.0

### DIFF
--- a/installer/roles/oc-cluster-up/defaults/main.yml
+++ b/installer/roles/oc-cluster-up/defaults/main.yml
@@ -7,6 +7,6 @@ hawkular_metrics: "false"
 
 host_config_dir: "{{playbook_dir}}/../ui"
 
-cluster_version: v3.6.0-rc.0
+cluster_version: v3.6.0
 
 cluster_public_hostname: "192.168.37.1"


### PR DESCRIPTION
Switching playbook to use origin v3.6.0 instead of v3.6.0-rc.0