### PR TITLE
Removing the OSCP template for fh-sync-server

### DIFF
--- a/installer/roles/template-service-broker-setup/defaults/main.yml
+++ b/installer/roles/template-service-broker-setup/defaults/main.yml
@@ -4,9 +4,6 @@
 openshift_username: system:admin
 openshift_project: openshift
 
-templates:
-- https://raw.githubusercontent.com/feedhenry/fh-sync-server/master/fh-sync-server-DEVELOPMENT.yaml
-
 group: "system:openshift:templateservicebroker-client"
 roles:
 - "system:unauthenticated"

--- a/installer/roles/template-service-broker-setup/tasks/main.yml
+++ b/installer/roles/template-service-broker-setup/tasks/main.yml
@@ -5,15 +5,6 @@
   shell: oc login -u system:admin
   changed_when: false
 
-- name: Create templates in required project
-  shell: oc create -f {{ item }} -n {{ openshift_project }}
-  register: oc_create
-  failed_when:
-  - oc_create.rc != 0
-  - oc_create.stderr.find('AlreadyExists') == -1
-  changed_when: oc_create.rc == 0
-  with_items: "{{ templates }}"
-
 - name: Add cluster roles to group
   shell: oc adm policy add-cluster-role-to-group {{ group }} {{ roles | join(' ') }}
   changed_when: false


### PR DESCRIPTION
w/ this change, and a new installation, there is only the playbook for FH-Sync in the service catalog 