### PR TITLE
Docker io

### DIFF
--- a/cmd/android-apb/Makefile
+++ b/cmd/android-apb/Makefile
@@ -1,3 +1,4 @@
+DOCKERHOST = docker.io
 DOCKERORG = feedhenry
 USER=$(shell id -u)
 PWS=$(shell pwd)
@@ -12,4 +13,4 @@ apb_build:
 
 .PHONY: docker_push
 docker_push:
-	docker push $(DOCKERORG)/android-app-apb:$(TAG)
+	docker push $(DOCKERHOST)/$(DOCKERORG)/android-app-apb:$(TAG)

--- a/cmd/cordova-apb/Makefile
+++ b/cmd/cordova-apb/Makefile
@@ -1,3 +1,4 @@
+DOCKERHOST = docker.io
 DOCKERORG = feedhenry
 USER=$(shell id -u)
 PWS=$(shell pwd)
@@ -11,4 +12,4 @@ apb_build:
 
 .PHONY: docker_push
 docker_push:
-	docker push $(DOCKERORG)/cordova-app-apb:$(TAG)
+	docker push $(DOCKERHOST)/$(DOCKERORG)/cordova-app-apb:$(TAG)

--- a/cmd/ios-apb/Makefile
+++ b/cmd/ios-apb/Makefile
@@ -1,3 +1,4 @@
+DOCKERHOST = docker.io
 DOCKERORG = feedhenry
 USER=$(shell id -u)
 PWS=$(shell pwd)
@@ -11,4 +12,4 @@ apb_build:
 
 .PHONY: docker_push
 docker_push:
-	docker push $(DOCKERORG)/ios-app-apb:$(TAG)
+	docker push $(DOCKERHOST)/$(DOCKERORG)/ios-app-apb:$(TAG)

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -27,9 +27,9 @@ make image TAG=$(TAG)
 Next update the main template in ```artifacts/openshift/template.json``` change the IMAGE_TAG parameter
 to match the the TAG you have just created.
 
-docker push feedhenry/mcp-standalone:$(TAG)
+```bash
+docker push docker.io/feedhenry/mcp-standalone:$(TAG)
 # builds the 3 different apbs for mcp (android, cordova, iOS) copying over the main template
 make apbs TAG=$(TAG)
 ```
-
 


### PR DESCRIPTION
On Fedora, when using the `docker` CLI from the distribution (e.g. `docker-1.13.1-22.gitb5e3294.fc26.x86_64`) you do need to specify the DOCKERHOST (`docker.io`). On Mac having this does not cause any harm 