### PR TITLE
Makefile lacks docker.io when building tag image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ image: build
 	mkdir -p tmp
 	cp ./mcp-api tmp
 	cp artifacts/Dockerfile tmp
-	cd tmp && docker build -t feedhenry/mcp-standalone:$(TAG) .
+	cd tmp && docker build -t docker.io/feedhenry/mcp-standalone:$(TAG) .
 	rm -rf tmp
 
 run_server:

--- a/cmd/android-apb/Makefile
+++ b/cmd/android-apb/Makefile
@@ -9,7 +9,7 @@ build_and_push: apb_build docker_push
 .PHONY: apb_build
 apb_build:
 	docker run --rm -u $(USER) -v $(PWD):/mnt:z feedhenry/apb prepare
-	docker build -t $(DOCKERORG)/android-app-apb:$(TAG) .
+	docker build -t $(DOCKERHOST)/$(DOCKERORG)/android-app-apb:$(TAG) .
 
 .PHONY: docker_push
 docker_push:

--- a/cmd/cordova-apb/Makefile
+++ b/cmd/cordova-apb/Makefile
@@ -8,7 +8,7 @@ build_and_push: apb_build docker_push
 .PHONY: apb_build
 apb_build:
 	docker run --rm -u $(USER) -v $(PWD):/mnt:z feedhenry/apb prepare
-	docker build -t $(DOCKERORG)/cordova-app-apb:$(TAG) .
+	docker build -t $(DOCKERHOST)/$(DOCKERORG)/cordova-app-apb:$(TAG) .
 
 .PHONY: docker_push
 docker_push:

--- a/cmd/ios-apb/Makefile
+++ b/cmd/ios-apb/Makefile
@@ -8,7 +8,7 @@ build_and_push: apb_build docker_push
 .PHONY: apb_build
 apb_build:
 	docker run --rm -u $(USER) -v $(PWD):/mnt:z feedhenry/apb prepare
-	docker build -t $(DOCKERORG)/ios-app-apb:$(TAG) .
+	docker build -t $(DOCKERHOST)/$(DOCKERORG)/ios-app-apb:$(TAG) .
 
 .PHONY: docker_push
 docker_push:


### PR DESCRIPTION
Running `docker push docker.io/feedhenry/mcp-standalone:0.0.5`, gave me:
```
The push refers to a repository [docker.io/feedhenry/mcp-standalone]
```

And indeed, the fqdin (full-qualified-docker-image-name :smile:) did lack the docker.io:
```
 docker images
REPOSITORY                                                      TAG                 IMAGE ID            CREATED              SIZE
feedhenry/mcp-standalone                                        0.0.5               de551e7c8162        About a minute ago   273 MB
...
...
```

After changing the `Makefile` this went fine.


**RESULT:** 

See the `0.0.5` tag here:
https://hub.docker.com/r/feedhenry/mcp-standalone/tags/

