### PR TITLE
using docker.io registry as the DOCKERHOST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ image: build
 	mkdir -p tmp
 	cp ./mcp-api tmp
 	cp artifacts/Dockerfile tmp
-	cd tmp && docker build -t feedhenry/mcp-standalone:$(TAG) .
+	cd tmp && docker build -t docker.io/feedhenry/mcp-standalone:$(TAG) .
 	rm -rf tmp
 
 run_server:

--- a/cmd/android-apb/Makefile
+++ b/cmd/android-apb/Makefile
@@ -1,3 +1,4 @@
+DOCKERHOST = docker.io
 DOCKERORG = feedhenry
 USER=$(shell id -u)
 PWS=$(shell pwd)
@@ -8,8 +9,8 @@ build_and_push: apb_build docker_push
 .PHONY: apb_build
 apb_build:
 	docker run --rm -u $(USER) -v $(PWD):/mnt:z feedhenry/apb prepare
-	docker build -t $(DOCKERORG)/android-app-apb:$(TAG) .
+	docker build -t $(DOCKERHOST)/$(DOCKERORG)/android-app-apb:$(TAG) .
 
 .PHONY: docker_push
 docker_push:
-	docker push $(DOCKERORG)/android-app-apb:$(TAG)
+	docker push $(DOCKERHOST)/$(DOCKERORG)/android-app-apb:$(TAG)

--- a/cmd/cordova-apb/Makefile
+++ b/cmd/cordova-apb/Makefile
@@ -1,3 +1,4 @@
+DOCKERHOST = docker.io
 DOCKERORG = feedhenry
 USER=$(shell id -u)
 PWS=$(shell pwd)
@@ -7,8 +8,8 @@ build_and_push: apb_build docker_push
 .PHONY: apb_build
 apb_build:
 	docker run --rm -u $(USER) -v $(PWD):/mnt:z feedhenry/apb prepare
-	docker build -t $(DOCKERORG)/cordova-app-apb:$(TAG) .
+	docker build -t $(DOCKERHOST)/$(DOCKERORG)/cordova-app-apb:$(TAG) .
 
 .PHONY: docker_push
 docker_push:
-	docker push $(DOCKERORG)/cordova-app-apb:$(TAG)
+	docker push $(DOCKERHOST)/$(DOCKERORG)/cordova-app-apb:$(TAG)

--- a/cmd/ios-apb/Makefile
+++ b/cmd/ios-apb/Makefile
@@ -1,3 +1,4 @@
+DOCKERHOST = docker.io
 DOCKERORG = feedhenry
 USER=$(shell id -u)
 PWS=$(shell pwd)
@@ -7,8 +8,8 @@ build_and_push: apb_build docker_push
 .PHONY: apb_build
 apb_build:
 	docker run --rm -u $(USER) -v $(PWD):/mnt:z feedhenry/apb prepare
-	docker build -t $(DOCKERORG)/ios-app-apb:$(TAG) .
+	docker build -t $(DOCKERHOST)/$(DOCKERORG)/ios-app-apb:$(TAG) .
 
 .PHONY: docker_push
 docker_push:
-	docker push $(DOCKERORG)/ios-app-apb:$(TAG)
+	docker push $(DOCKERHOST)/$(DOCKERORG)/ios-app-apb:$(TAG)

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -26,7 +26,7 @@ make image TAG=$(TAG)
 Next update the main template in ```artifacts/openshift/template.json``` change the IMAGE_TAG parameter
 to match the the TAG you have just created.
 ```bash
-docker push feedhenry/mcp-standalone:$(TAG)
+docker push docker.io/feedhenry/mcp-standalone:$(TAG)
 # builds the 3 different apbs for mcp (android, cordova, iOS) copying over the main template
 make apbs TAG=$(TAG)
 ```


### PR DESCRIPTION
Needed for Fedora, when using its (from the distribution) docker CLI :penguin: 