### PR TITLE
Refactor charts into components

### DIFF
--- a/pkg/mobile/metrics/keycloak.go
+++ b/pkg/mobile/metrics/keycloak.go
@@ -57,8 +57,7 @@ func (kc *Keycloak) Gather() ([]*metric, error) {
 		return nil, &noServiceProvisionedErr{Message: " no keycloak service present in namespace "}
 	}
 	kcService := kcServices[0] //TODO deal with more than one
-	//TODO get protocol from secret
-	host := "http://" + kcService.Host
+	host := kcService.Host
 	username := kcService.Params["admin_username"]
 	pass := kcService.Params["admin_password"]
 	realm := kcService.Params["realm"]

--- a/pkg/mobile/metrics/keycloak_test.go
+++ b/pkg/mobile/metrics/keycloak_test.go
@@ -45,7 +45,7 @@ func TestKeycloak_Gather(t *testing.T) {
 								Data: map[string][]byte{
 									"admin_password": []byte("admin"),
 									"admin_username": []byte("admin"),
-									"uri":            []byte("keycloak-project2.192.168.37.1.nip.io"),
+									"uri":            []byte("http://keycloak-project2.192.168.37.1.nip.io"),
 									"realm":          []byte("test"),
 									"name":           []byte("keycloak"),
 									"type":           []byte("keycloak"),
@@ -141,7 +141,7 @@ func TestKeycloak_Gather(t *testing.T) {
 								Data: map[string][]byte{
 									"admin_password": []byte("admin"),
 									"admin_username": []byte("admin"),
-									"uri":            []byte("keycloak-project2.192.168.37.1.nip.io"),
+									"uri":            []byte("http://keycloak-project2.192.168.37.1.nip.io"),
 									"realm":          []byte("test"),
 									"name":           []byte("keycloak"),
 									"type":           []byte("keycloak"),

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -40,6 +40,14 @@
     <script src="/scripts/components/get-started.component.js"></script>
     <script src="/scripts/components/modal.directive.js"></script>
     <script src="/scripts/components/qr-code.directive.js"></script>
+    <script src="/scripts/components/mp-sync-trend-chart.component.js"></script>
+    <script src="/scripts/components/mp-sync-queues-workers.component.js"></script>
+    <script src="/scripts/components/mp-sync-timings.component.js"></script>
+    <script src="/scripts/components/mp-timings-chart.directive.js"></script>
+    <script src="/scripts/components/mp-sparkline-chart.directive.js"></script>
+    <script src="/scripts/components/mp-keycloak-chart.component.js"></script>
+    <script src="/scripts/components/mp-default-service-chart.component.js"></script>
+    <script src="/scripts/components/mp-line-chart.directive.js"></script>
     <script src="/scripts/components/create-service.component.js"></script>
     <script src="/scripts/components/mobile-overview/object-card.component.js"></script>
     <script src="/scripts/components/mobile-overview/overview.component.js"></script>

--- a/ui/public/scripts/app.js
+++ b/ui/public/scripts/app.js
@@ -71,37 +71,31 @@ var resolveMCPRoute = {
   ]
 };
 
-angular
-  .module('mobileControlPanelApp', [
-    'openshiftConsole',
-    'patternfly.charts',
-    'patternfly.card'
-  ])
-  .config([
-    '$routeProvider',
-    function($routeProvider) {
-      $routeProvider
-        .when('/project/:project/create-mobileapp', {
-          templateUrl: 'extensions/mcp/views/create-mobileapp.html',
-          controller: 'CreateMobileappController',
-          resolve: resolveMCPRoute
-        })
-        .when('/project/:project/browse/mobileoverview', {
-          templateUrl: 'extensions/mcp/views/mobileoverview.html',
-          controller: 'MobileOverviewController',
-          reloadOnSearch: false,
-          resolve: resolveMCPRoute
-        })
-        .when('/project/:project/browse/mobileapps/:mobileapp', {
-          templateUrl: 'extensions/mcp/views/mobileapp.html',
-          controller: 'MobileAppController',
-          reloadOnSearch: false,
-          resolve: resolveMCPRoute
-        })
-        .when('/project/:project/browse/mobileservices/:service', {
-          templateUrl: 'extensions/mcp/views/mobileservice.html',
-          controller: 'MobileServiceController',
-          resolve: resolveMCPRoute
-        });
-    }
-  ]);
+angular.module('mobileControlPanelApp', ['openshiftConsole']).config([
+  '$routeProvider',
+  function($routeProvider) {
+    $routeProvider
+      .when('/project/:project/create-mobileapp', {
+        templateUrl: 'extensions/mcp/views/create-mobileapp.html',
+        controller: 'CreateMobileappController',
+        resolve: resolveMCPRoute
+      })
+      .when('/project/:project/browse/mobileoverview', {
+        templateUrl: 'extensions/mcp/views/mobileoverview.html',
+        controller: 'MobileOverviewController',
+        reloadOnSearch: false,
+        resolve: resolveMCPRoute
+      })
+      .when('/project/:project/browse/mobileapps/:mobileapp', {
+        templateUrl: 'extensions/mcp/views/mobileapp.html',
+        controller: 'MobileAppController',
+        reloadOnSearch: false,
+        resolve: resolveMCPRoute
+      })
+      .when('/project/:project/browse/mobileservices/:service', {
+        templateUrl: 'extensions/mcp/views/mobileservice.html',
+        controller: 'MobileServiceController',
+        resolve: resolveMCPRoute
+      });
+  }
+]);

--- a/ui/public/scripts/components/mp-default-service-chart.component.js
+++ b/ui/public/scripts/components/mp-default-service-chart.component.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * @ngdoc component
+ * @name mcp.component:mp-default-service-chart
+ * @description
+ * # mp-default-service-chart
+ */
+angular.module('mobileControlPanelApp').component('mpDefaultServiceChart', {
+  template: `<div class="row">
+                <div ng-repeat="chart in $ctrl.chartData">
+                  <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+                    <div class="mp-sync-trend-chart card-pf">
+                      <h3>{{chart[1][0]}}</h3>
+                      <mp-line-chart chart-data=chart chart-config=chartConfig></mp-line-chart>
+                    </div>
+                  </div>
+              </div>
+            </div>`,
+  bindings: {
+    chartData: '<'
+  },
+  controller: [
+    '$scope',
+    function($scope) {
+      $scope.chartConfig = {
+        axis: {
+          x: {
+            type: 'timeseries',
+            tick: {
+              format: '%H:%M:%S'
+            }
+          }
+        },
+        data: {
+          x: 'x',
+          xFormat: '%Y-%m-%d %H:%M:%S'
+        }
+      };
+    }
+  ]
+});

--- a/ui/public/scripts/components/mp-keycloak-chart.component.js
+++ b/ui/public/scripts/components/mp-keycloak-chart.component.js
@@ -49,8 +49,7 @@ angular.module('mobileControlPanelApp').component('mpKeycloakChart', {
           error: 0
         }
       };
-
-      var loginSuccessChart = _.findWhere($scope.$ctrl.chartData, {
+      var loginSuccessChart = _.find($scope.$ctrl.chartData, {
         title: 'LOGIN'
       });
       if (loginSuccessChart) {
@@ -59,7 +58,7 @@ angular.module('mobileControlPanelApp').component('mpKeycloakChart', {
             loginSuccessChart.data.columns[1].length - 1
           ];
       }
-      var loginErrorChart = _.findWhere($scope.$ctrl.chartData, {
+      var loginErrorChart = _.find($scope.$ctrl.chartData, {
         title: 'LOGIN_ERROR'
       });
       if (loginErrorChart) {
@@ -68,7 +67,7 @@ angular.module('mobileControlPanelApp').component('mpKeycloakChart', {
             loginErrorChart.data.columns[1].length - 1
           ];
       }
-      var registrationSuccessChart = _.findWhere($scope.$ctrl.chartData, {
+      var registrationSuccessChart = _.find($scope.$ctrl.chartData, {
         title: 'REGISTER'
       });
       if (registrationSuccessChart) {
@@ -77,7 +76,7 @@ angular.module('mobileControlPanelApp').component('mpKeycloakChart', {
             registrationSuccessChart.data.columns[1].length - 1
           ];
       }
-      var registrationErrorChart = _.findWhere($scope.$ctrl.chartData, {
+      var registrationErrorChart = _.find($scope.$ctrl.chartData, {
         title: 'REGISTER_ERROR'
       });
       if (registrationErrorChart) {

--- a/ui/public/scripts/components/mp-keycloak-chart.component.js
+++ b/ui/public/scripts/components/mp-keycloak-chart.component.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * @ngdoc component
+ * @name mcp.component:mp-keycloak-chart
+ * @description
+ * # mp-keycloak-chart
+ */
+angular.module('mobileControlPanelApp').component('mpKeycloakChart', {
+  template: `<div class="col-xs-6 col-md-6 col-lg-6">
+              <div class="card-pf card-pf-accented card-pf-aggregate-status">
+                <h2 class="card-pf-title">
+                  <span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">{{metrics.logins.total}}</span> Logins
+                </h2>
+                <div class="card-pf-body">
+                  <p class="card-pf-aggregate-status-notifications">
+                    <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span>{{metrics.logins.success}}</span>
+                    <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>{{metrics.logins.error}}</span>
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div ng-if-end class="col-xs-6 col-md-6 col-lg-6">
+              <div class="card-pf card-pf-accented card-pf-aggregate-status">
+                <h2 class="card-pf-title">
+                  <span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">{{metrics.registrations.total}}</span> Registrations
+                </h2>
+                <div class="card-pf-body">
+                  <p class="card-pf-aggregate-status-notifications">
+                    <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span>{{metrics.registrations.success}}</span>
+                    <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>{{metrics.registrations.error}}</span>
+                  </p>
+                </div>
+              </div>
+            </div>`,
+  bindings: {
+    chartData: '<'
+  },
+  controller: [
+    '$scope',
+    function($scope) {
+      $scope.metrics = {
+        logins: {
+          success: 0,
+          error: 0
+        },
+        registrations: {
+          success: 0,
+          error: 0
+        }
+      };
+
+      var loginSuccessChart = _.findWhere($scope.$ctrl.chartData, {
+        title: 'LOGIN'
+      });
+      if (loginSuccessChart) {
+        $scope.metrics.logins.success =
+          loginSuccessChart.data.columns[1][
+            loginSuccessChart.data.columns[1].length - 1
+          ];
+      }
+      var loginErrorChart = _.findWhere($scope.$ctrl.chartData, {
+        title: 'LOGIN_ERROR'
+      });
+      if (loginErrorChart) {
+        $scope.metrics.logins.error =
+          loginErrorChart.data.columns[1][
+            loginErrorChart.data.columns[1].length - 1
+          ];
+      }
+      var registrationSuccessChart = _.findWhere($scope.$ctrl.chartData, {
+        title: 'REGISTER'
+      });
+      if (registrationSuccessChart) {
+        $scope.metrics.registrations.success =
+          registrationSuccessChart.data.columns[1][
+            registrationSuccessChart.data.columns[1].length - 1
+          ];
+      }
+      var registrationErrorChart = _.findWhere($scope.$ctrl.chartData, {
+        title: 'REGISTER_ERROR'
+      });
+      if (registrationErrorChart) {
+        $scope.metrics.registrations.error =
+          registrationErrorChart.data.columns[1][
+            registrationErrorChart.data.columns[1].length - 1
+          ];
+      }
+
+      $scope.metrics.logins.total =
+        $scope.metrics.logins.success + $scope.metrics.logins.error;
+      $scope.metrics.registrations.total =
+        $scope.metrics.registrations.success +
+        $scope.metrics.registrations.error;
+      $scope.metrics = $scope.metrics;
+    }
+  ]
+});

--- a/ui/public/scripts/components/mp-line-chart.directive.js
+++ b/ui/public/scripts/components/mp-line-chart.directive.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * @ngdoc component
+ * @name mcp.directive:mp-line-chart
+ * @description
+ * # mp-line-chart
+ */
+angular.module('mobileControlPanelApp').directive('mpLineChart', function() {
+  return {
+    template: `<div class="mp-linechart-container">
+                  <div ng-if="noData" class="empty-chart-content">
+                    <span class="pficon pficon-info"></span><span>No data available</span>
+                  </div>
+              </div>`,
+    scope: {
+      chartData: '<',
+      chartConfig: '<?'
+    },
+    link: function(scope, element, attrs) {
+      if (!scope.chartData) {
+        scope.noData = true;
+        return;
+      }
+
+      let defaultConfig = $()
+        .c3ChartDefaults()
+        .getDefaultLineConfig();
+
+      const config = Object.assign(defaultConfig, scope.chartConfig);
+      config.data = config.data ? config.data : {};
+      config.data.columns = scope.chartData;
+      const chart = c3.generate(config);
+      element.find('.mp-linechart-container').append(chart.element);
+    }
+  };
+});

--- a/ui/public/scripts/components/mp-sparkline-chart.directive.js
+++ b/ui/public/scripts/components/mp-sparkline-chart.directive.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * @ngdoc component
+ * @name mcp.directive:mp-sparkline-chart
+ * @description
+ * # mp-sparkline-chart
+ */
+angular
+  .module('mobileControlPanelApp')
+  .directive('mpSparklineChart', function() {
+    return {
+      template: `<div class="mp-sparkline-container">
+                  <div ng-if="noData" class="empty-chart-content">
+                    <span class="pficon pficon-info"></span><span>No data available</span>
+                  </div>
+                </div>`,
+      scope: {
+        chartData: '<',
+        chartConfig: '<?'
+      },
+      link: function(scope, element, attrs) {
+        if (!scope.chartData) {
+          scope.noData = true;
+          return;
+        }
+
+        let defaultConfig = $()
+          .c3ChartDefaults()
+          .getDefaultSparklineConfig();
+
+        const config = Object.assign(defaultConfig, scope.chartConfig);
+        config.data = config.data ? config.data : {};
+        config.data.columns = scope.chartData;
+        const chart = c3.generate(config);
+        element.find('.mp-sparkline-container').append(chart.element);
+      }
+    };
+  });

--- a/ui/public/scripts/components/mp-sync-queues-workers.component.js
+++ b/ui/public/scripts/components/mp-sync-queues-workers.component.js
@@ -1,0 +1,115 @@
+'use strict';
+
+/**
+ * @ngdoc component
+ * @name mcp.component:mp-sync-queues-workers
+ * @description
+ * # mp-sync-queues-workers
+ */
+angular.module('mobileControlPanelApp').component('mpSyncQueuesWorkers', {
+  template: `<div class="card-pf mp-sync-queues-workers">
+              <div class="card-pf-heading row">
+                <h2 class="col-sm-6 col-xs-6">Queues &amp; Workers</h2>
+                <span class="col-sm-6 col-xs-6">Last 30 Readings</span>
+              </div>
+              <div class="row">
+                <mp-sync-trend-chart ng-repeat="trend in trendData" chart-data=trend.chart config=trend.config></mp-sync-trend-chart>
+              </div>
+            </div>`,
+  bindings: {
+    chartData: '<'
+  },
+  controller: [
+    '$scope',
+    function($scope) {
+      $scope.trendData = [];
+
+      const metrics = {
+        pending_worker_queue_count: {
+          title: 'Pending Queue',
+          unit: 'Items Processed ',
+          supplementId: 'pending_worker_queue_count_total',
+          color: '#1f77b4'
+        },
+        ack_worker_queue_count: {
+          title: 'Ack Queue',
+          unit: 'Items Processed',
+          supplementId: 'ack_worker_queue_count_total',
+          color: '#2ca02c'
+        },
+        sync_worker_queue_count: {
+          title: 'Sync Queue',
+          unit: 'Items Processed',
+          supplementId: 'sync_worker_queue_count_total',
+          color: '#ff7f0e'
+        },
+        pending_worker_process_time_ms: {
+          title: 'Pending Worker',
+          unit: 'ms avg process time',
+          supplementId: 'pending_worker_process_time_ms_avg',
+          color: '#1f77b4'
+        },
+        ack_worker_process_time_ms_avg: {
+          title: 'Ack Worker',
+          unit: 'ms avg process time',
+          supplementId: 'ack_worker_process_time_ms_avg_avg',
+          color: '#2ca02c'
+        },
+        sync_worker_process_time_ms: {
+          title: 'Sync Worker',
+          unit: 'ms avg process time',
+          supplementId: 'sync_worker_process_time_ms_avg',
+          color: '#ff7f0e'
+        }
+      };
+
+      const chartDataReduce = function(chartData, acc, key) {
+        let metricConfig = metrics[key];
+        let chart = chartData.filter(chart => chart[1][0] === key).pop();
+        let supplementChart = chartData
+          .filter(chart => chart[1][0] === metricConfig.supplementId)
+          .pop();
+
+        if (!chart) {
+          acc.push({ config: { title: metricConfig.title } });
+          return acc;
+        }
+
+        let config = {
+          chart: {
+            data: {
+              type: 'area'
+            },
+            point: {
+              r: 0
+            },
+            color: {
+              pattern: [metricConfig.color]
+            },
+            tooltip: {
+              contents: function(d) {
+                return (
+                  '<p class="mp-sync-trend-tooltip">' + d[0].value + '</p>'
+                );
+              }
+            }
+          }
+        };
+
+        config.title = metricConfig.title;
+        config.unit = metricConfig.unit;
+        if (supplementChart) {
+          config.total = supplementChart[1][supplementChart[1].length - 1];
+        }
+
+        acc.push({ config: config, chart: [chart[1]] });
+        return acc;
+      };
+
+      $scope.trendData = Object.keys(metrics).reduce(
+        chartDataReduce.bind(null, $scope.$ctrl.chartData),
+        []
+      );
+    }
+  ]
+});

--- a/ui/public/scripts/components/mp-sync-timings.component.js
+++ b/ui/public/scripts/components/mp-sync-timings.component.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/**
+ * @ngdoc component
+ * @name mcp.component:mp-sync-timings
+ * @description
+ * # mp-sync-timings
+ */
+angular.module('mobileControlPanelApp').component('mpSyncTimings', {
+  template: `<div class="card-pf mp-sync-timings">
+              <div class="card-pf-heading row">
+                <h2 class="col-sm-6 col-xs-6">Timings (milliseconds)</h2>
+                <span class="col-sm-6 col-xs-6">Last 30 Readings</span>
+              </div>
+              <div class="row">
+                <mp-timings-chart chart-data=chartData></mp-timings-chart>
+              </div>
+            </div>`,
+  bindings: {
+    chartData: '<'
+  },
+  controller: [
+    '$scope',
+    function($scope) {
+      const metricsToDisplay = ['mongodb_operation_time_', 'api_process_time_'];
+      $scope.chartData = [];
+
+      if (Array.isArray($scope.$ctrl.chartData[0])) {
+        $scope.chartData.push($scope.$ctrl.chartData[0][0]);
+      }
+
+      $scope.$ctrl.chartData.forEach((chart, index) => {
+        if (metricsToDisplay.indexOf(chart[1][0]) === -1) {
+          return;
+        }
+
+        $scope.chartData.push(chart[1]);
+      });
+    }
+  ]
+});

--- a/ui/public/scripts/components/mp-sync-timings.component.js
+++ b/ui/public/scripts/components/mp-sync-timings.component.js
@@ -30,11 +30,13 @@ angular.module('mobileControlPanelApp').component('mpSyncTimings', {
       }
 
       $scope.$ctrl.chartData.forEach((chart, index) => {
-        if (metricsToDisplay.indexOf(chart[1][0]) === -1) {
-          return;
-        }
+        metricsToDisplay.forEach(metric => {
+          if (chart[1][0].indexOf(metric) === -1) {
+            return;
+          }
 
-        $scope.chartData.push(chart[1]);
+          $scope.chartData.push(chart[1]);
+        });
       });
     }
   ]

--- a/ui/public/scripts/components/mp-sync-trend-chart.component.js
+++ b/ui/public/scripts/components/mp-sync-trend-chart.component.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/**
+ * @ngdoc component
+ * @name mcp.component:mp-sync-trend-chart
+ * @description
+ * # mp-sync-trend-chart
+ */
+angular.module('mobileControlPanelApp').component('mpSyncTrendChart', {
+  template: `<div class="col-xs-12 col-sm-4 col-md-4">
+              <div class="mp-sync-trend-chart card-pf">
+                <h2 class="card-pf-heading">{{$ctrl.config.title}}</h2>
+                <div>
+                   <span class="count">{{$ctrl.config.total}}</span>
+                   <span class="unit">{{$ctrl.config.unit}}</span>
+                </div>
+                <mp-sparkline-chart chart-data="$ctrl.chartData" chart-config=$ctrl.config.chart></mp-sparkline-chart>
+              </div>
+            </div>`,
+  bindings: {
+    chartData: '<',
+    config: '<?'
+  }
+});

--- a/ui/public/scripts/components/mp-timings-chart.directive.js
+++ b/ui/public/scripts/components/mp-timings-chart.directive.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * @ngdoc component
+ * @name mcp.directive:mp-timings-chart
+ * @description
+ * # mp-timings-chart
+ */
+angular.module('mobileControlPanelApp').directive('mpTimingsChart', function() {
+  return {
+    template: `<div class="mp-timings-container col-xs-12"></div>`,
+    scope: {
+      chartData: '<',
+      chartConfig: '<?'
+    },
+    link: function(scope, element, attrs) {
+      let defaultConfig = $()
+        .c3ChartDefaults()
+        .getDefaultLineConfig();
+
+      defaultConfig.axis = {
+        x: {
+          type: 'timeseries',
+          tick: {
+            format: '%Y-%m-%d %H:%M:%S'
+          }
+        }
+      };
+      defaultConfig.data = {
+        x: 'x',
+        xFormat: '%Y-%m-%d %H:%M:%S',
+        columns: scope.chartData,
+        type: 'spline'
+      };
+      defaultConfig.point = {
+        r: 2
+      };
+      let config = Object.assign(defaultConfig, scope.chartConfig);
+      const chart = c3.generate(config);
+      element.find('.mp-timings-container').append(chart.element);
+    }
+  };
+});

--- a/ui/public/scripts/controllers/mobileservice.js
+++ b/ui/public/scripts/controllers/mobileservice.js
@@ -25,208 +25,45 @@ angular.module('mobileControlPanelApp').controller('MobileServiceController', [
       }
     ];
 
-    $scope.charts = [];
+    const knownServices = ['fh-sync-server', 'keycloak'];
+    $scope.chartData = [];
     $scope.integrations = [];
-    Promise.all([
-      mcpApi.mobileService($routeParams.service, 'true').then(s => {
-        $scope.service = s;
-        $scope.integrations = Object.keys(s.integrations);
-      }),
-      mcpApi.mobileApps().then(apps => {
-        $scope.mobileappsCount = apps.length;
-        $scope.mobileapps = {};
-        for (var i = 0; i < apps.length; i++) {
-          let app = apps[i];
-          $scope.mobileapps[app.clientType] = 'true';
-        }
-        $scope.clients = Object.keys($scope.mobileapps);
-        $scope.clientType = $scope.clients[0];
+    mcpApi
+      .mobileServiceMetrics($routeParams.service)
+      .then(chartData => {
+        $scope.chartData = chartData;
+        $timeout(() => {});
       })
-    ])
-      .then(() => {
-        // wait for apps & services, and hence the UI being redrawn,
-        // before fetching metrics.
-        // Charts may not initialise if the UI isn't ready with the div placeholders
-        mcpApi.mobileServiceMetrics($routeParams.service).then(data => {
-          var charts = [];
-          var chartConfigs = [];
-          data.forEach(columns => {
-            var c3ChartDefaults = $().c3ChartDefaults();
-            var chartConfig = c3ChartDefaults.getDefaultLineConfig();
-            chartConfig.axis = {
-              x: {
-                type: 'timeseries',
-                tick: {
-                  // 11:34:55
-                  format: '%H:%M:%S'
-                }
-              }
-            };
-            chartConfig.data = {
-              x: 'x',
-              xFormat: '%Y-%m-%d %H:%M:%S',
-              columns: columns,
-              type: 'line'
-            };
-            var chartName = columns[1][0];
-            chartConfig.bindto = '#line-chart-' + chartName;
-            chartConfig.title = chartName;
-            charts.push(chartConfig);
-          });
-
-          $scope.charts = charts;
-        });
-      })
-      .catch(error => {
-        console.error(error);
+      .catch(err => {
+        console.error('Error loading Service Metrics', err);
       });
 
-    $scope.$watch('charts', charts => {
-      if ($scope && $scope.service) {
-        if ($scope.service.name === 'fh-sync-server') {
-          // custom layout for fh-sync-server
-          // render all queue & worker sparklines
-          [
-            ['sync_worker_queue_count', '#ff7f0e', 'total'],
-            ['ack_worker_queue_count', '#2ca02c', 'total'],
-            ['pending_worker_queue_count', '#1f77b4', 'total'],
-            ['sync_worker_process_time_ms', '#ff7f0e', 'avg'],
-            ['ack_worker_process_time_ms', '#2ca02c', 'avg'],
-            ['pending_worker_process_time_ms', '#1f77b4', 'avg']
-          ].forEach(metric => {
-            var chart = _.findWhere(charts, {
-              title: metric[0]
-            });
-            if (chart) {
-              var sparklineConfig = $()
-                .c3ChartDefaults()
-                .getDefaultSparklineConfig();
-              sparklineConfig.bindto = '#chart-pf-' + metric[0];
-              chart.data.columns[1][0] = ''; // no suffix on hover
-              sparklineConfig.color = {
-                pattern: [metric[1]]
-              };
-              sparklineConfig.data = {
-                columns: [chart.data.columns[1]],
-                type: 'area'
-              };
-              sparklineConfig.point.r = 0;
-              c3.generate(sparklineConfig);
+    Promise.all([
+      mcpApi.mobileService($routeParams.service, 'true'),
+      mcpApi.mobileApps()
+    ])
+      .then(serviceInfo => {
+        const [service = {}, apps = []] = serviceInfo;
 
-              // set the total/avg value
-              var supplementId = metric[0] + '_' + metric[2];
-              var supplementChart = _.findWhere(charts, {
-                title: supplementId
-              });
-              if (supplementChart) {
-                $scope[supplementId] =
-                  supplementChart.data.columns[1][
-                    supplementChart.data.columns[1].length - 1
-                  ];
-              }
-            }
-          });
+        $scope.service = service;
+        $scope.integrations = Object.keys(service.integrations);
 
-          // Gather all 'timings' data to render into 1 chart
-          var c3ChartDefaults = $().c3ChartDefaults();
-          var chartConfig = c3ChartDefaults.getDefaultLineConfig();
-          chartConfig.axis = {
-            x: {
-              type: 'timeseries',
-              tick: {
-                // 11:34:55
-                format: '%H:%M:%S'
-              }
-            }
-          };
-          chartConfig.data = {
-            x: 'x',
-            xFormat: '%Y-%m-%d %H:%M:%S',
-            columns: [charts[0].data.columns[0]], // copy over x values
-            type: 'spline'
-          };
-          chartConfig.point.r = 2;
-          chartConfig.bindto = '#line-chart-timings';
+        $scope.templateName = knownServices.includes(service.name)
+          ? service.name
+          : 'default-service';
 
-          charts.forEach(chart => {
-            if (
-              chart.title.indexOf('mongodb_operation_time_') === 0 ||
-              chart.title.indexOf('api_process_time_') === 0
-            ) {
-              chartConfig.data.columns.push(chart.data.columns[1]);
-            }
-          });
-
-          c3.generate(chartConfig);
-        } else if ($scope.service.name === 'keycloak') {
-          var keycloakMetrics = {
-            logins: {
-              success: 0,
-              error: 0
-            },
-            registrations: {
-              success: 0,
-              error: 0
-            }
-          };
-          // custom layout for keycloak
-          var loginSuccessChart = _.findWhere(charts, {
-            title: 'LOGIN'
-          });
-          if (loginSuccessChart) {
-            keycloakMetrics.logins.success =
-              loginSuccessChart.data.columns[1][
-                loginSuccessChart.data.columns[1].length - 1
-              ];
-          }
-          var loginErrorChart = _.findWhere(charts, {
-            title: 'LOGIN_ERROR'
-          });
-          if (loginErrorChart) {
-            keycloakMetrics.logins.error =
-              loginErrorChart.data.columns[1][
-                loginErrorChart.data.columns[1].length - 1
-              ];
-          }
-          var registrationSuccessChart = _.findWhere(charts, {
-            title: 'REGISTER'
-          });
-          if (registrationSuccessChart) {
-            keycloakMetrics.registrations.success =
-              registrationSuccessChart.data.columns[1][
-                registrationSuccessChart.data.columns[1].length - 1
-              ];
-          }
-          var registrationErrorChart = _.findWhere(charts, {
-            title: 'REGISTER_ERROR'
-          });
-          if (registrationErrorChart) {
-            keycloakMetrics.registrations.error =
-              registrationErrorChart.data.columns[1][
-                registrationErrorChart.data.columns[1].length - 1
-              ];
-          }
-
-          keycloakMetrics.logins.total =
-            keycloakMetrics.logins.success + keycloakMetrics.logins.error;
-          keycloakMetrics.registrations.total =
-            keycloakMetrics.registrations.success +
-            keycloakMetrics.registrations.error;
-          $scope.keycloakMetrics = keycloakMetrics;
-        } else {
-          $timeout(
-            () => {
-              // generic rendering of all data as line charts
-              charts.forEach(chart => {
-                c3.generate(chart);
-              });
-            },
-            0,
-            false
-          );
-        }
-      }
-    });
+        $scope.mobileappsCount = apps.length;
+        $scope.mobileapps = apps.reduce((acc, current) => {
+          acc[current.clientType] = 'true';
+          return acc;
+        }, {});
+        $scope.clients = Object.keys($scope.mobileapps);
+        $scope.clientType = $scope.clients[0];
+        $timeout(() => {});
+      })
+      .catch(err => {
+        console.error('Error loading Services', err);
+      });
 
     $scope.status = function(integration, service) {
       if ($scope.processing(integration, service)) {
@@ -299,6 +136,10 @@ angular.module('mobileControlPanelApp').controller('MobileServiceController', [
 
     $scope.installationOpt = function(type) {
       $scope.clientType = type;
+    };
+
+    $scope.dashboardSelected = function() {
+      window.dispatchEvent(new Event('resize'));
     };
   }
 ]);

--- a/ui/public/styles/main.less
+++ b/ui/public/styles/main.less
@@ -68,6 +68,7 @@
 }
 
 @import "mp-tabsets.less";
+@import "mp-sync-charts.less";
 
 .object-tab-title {
     position: relative;

--- a/ui/public/styles/mp-sync-charts.less
+++ b/ui/public/styles/mp-sync-charts.less
@@ -1,0 +1,48 @@
+.sync-heading {
+    h2 {
+      border-bottom: none;
+      margin: 20px 0px;
+      height: 30px;
+      line-height: 30px;
+    }
+
+    span {
+      text-align: right;
+      height: 30px;
+      line-height: 30px;
+      margin: 20px 0px;
+    }
+}
+
+
+.mp-sync-queues-workers {
+
+  .card-pf-heading {
+    position: relative;
+
+    .sync-heading
+  }
+
+
+  .mp-sync-trend-chart {
+    .count {
+      font-size: 28px;
+      font-weight: 300;
+    }
+  }
+}
+
+.mp-sync-timings {
+
+  .card-pf-heading {
+    position: relative;
+
+    .sync-heading
+  }
+}
+
+.mp-sync-trend-tooltip {
+  background-color: black;
+  color: white;
+  padding: 3px 5px;
+}

--- a/ui/public/views/default-service-chart.template.html
+++ b/ui/public/views/default-service-chart.template.html
@@ -1,0 +1,1 @@
+<mp-default-service-chart chart-data=chartData></mp-default-service-chart>

--- a/ui/public/views/fh-sync-server-chart.template.html
+++ b/ui/public/views/fh-sync-server-chart.template.html
@@ -1,0 +1,2 @@
+<mp-sync-queues-workers chart-data=chartData></mp-sync-queues-workers>
+<mp-sync-timings chart-data=chartData></mp-sync-timings>

--- a/ui/public/views/keycloak-chart.template.html
+++ b/ui/public/views/keycloak-chart.template.html
@@ -1,0 +1,1 @@
+<mp-keycloak-chart chart-data=chartData></mp-keycloak-chart>

--- a/ui/public/views/mobileservice.html
+++ b/ui/public/views/mobileservice.html
@@ -20,143 +20,16 @@
                 </h1>
               </div>
               <uib-tabset class="mp-tabsets" justified=true>
-                <uib-tab ng-if="service">
+                <uib-tab ng-if="service" active=true select=dashboardSelected()>
                   <uib-tab-heading>Dashboard</uib-tab-heading>
                   <div class="service-dashboard">
-                    <h2 class="dashboard-details">Details</h2>
-                    <dl class="dl-horizontal left">
-                      <dt>Description:</dt>
-                      <dd>{{ service.description }}</dd>
-                      <dt>Dashboard URL:</dt>
-                      <dd><a href="{{ service.host }}">{{service.host}}</a></dd>
-                      <dt ng-repeat-start="(key, value) in service.params">{{ key }}</dt>
-                      <dd ng-repeat-end>{{ value }}</dd>
-                    </dl>
-
+                    <div ng-include="'extensions/mcp/views/service-details.template.html'"></div>
                     <h2>Stats</h2>
-                    <div ng-if="service.name != 'fh-sync-server' && service.name != 'keycloak'" ng-repeat="chart in charts" class="col-xs-12 col-sm-6 col-md-3 mcp-dashboard-chart">
-                      <h3>{{chart.title}}</h3>
-                      <div id="line-chart-{{chart.title}}" class="line-chart-pf"></div>
+                    <div class="col-12">
+                      <div ng-include="'extensions/mcp/views/' + templateName + '-chart.template.html'"></div>
                     </div>
 
-                    <div ng-if-start="service.name == 'keycloak'" class="col-xs-6 col-md-6 col-lg-6">
-                      <div class="card-pf card-pf-accented card-pf-aggregate-status">
-                        <h2 class="card-pf-title">
-                          <span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">{{keycloakMetrics.logins.total}}</span> Logins
-                        </h2>
-                        <div class="card-pf-body">
-                          <p class="card-pf-aggregate-status-notifications">
-                            <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span>{{keycloakMetrics.logins.success}}</span>
-                            <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>{{keycloakMetrics.logins.error}}</span>
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                    <div ng-if-end class="col-xs-6 col-md-6 col-lg-6">
-                      <div class="card-pf card-pf-accented card-pf-aggregate-status">
-                        <h2 class="card-pf-title">
-                          <span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">{{keycloakMetrics.registrations.total}}</span> Registrations
-                        </h2>
-                        <div class="card-pf-body">
-                          <p class="card-pf-aggregate-status-notifications">
-                            <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span>{{keycloakMetrics.registrations.success}}</span>
-                            <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>{{keycloakMetrics.registrations.error}}</span>
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div ng-if="service.name == 'fh-sync-server'" class="col-12">
-
-                      <div class="card-pf card-pf-utilization">
-                        <div class="card-pf-heading">
-                          <p class="card-pf-heading-details">Last 30 readings</p>
-                          <h2 class="card-pf-title">
-                            Queues &amp; Workers
-                          </h2>
-                        </div>
-                        <div class="card-pf-body">
-                          <div class="row">
-                            <div class="col-xs-12 col-sm-4 col-md-4">
-                              <h3 class="card-pf-subtitle">Pending Queue</h3>
-                              <p class="card-pf-utilization-details">
-                                <span class="card-pf-utilization-card-details-count">{{pending_worker_queue_count_total}}</span>
-                                <span class="card-pf-utilization-card-details-line-1"></span>
-                                <span class="card-pf-utilization-card-details-line-2">items processed</span>
-                              </p>
-                              <div class="chart-pf-sparkline" id="chart-pf-pending_worker_queue_count"></div>
-                            </div>
-                            <div class="col-xs-12 col-sm-4 col-md-4">
-                              <h3 class="card-pf-subtitle">Ack Queue</h3>
-                              <p class="card-pf-utilization-details">
-                                <span class="card-pf-utilization-card-details-count">{{ack_worker_queue_count_total}}</span>
-                                <span class="card-pf-utilization-card-details-line-1"></span>
-                                <span class="card-pf-utilization-card-details-line-2">items processed</span>
-                              </p>
-                              <div class="chart-pf-sparkline" id="chart-pf-ack_worker_queue_count"></div>
-                            </div>
-                            <div class="col-xs-12 col-sm-4 col-md-4">
-                              <h3 class="card-pf-subtitle">Sync Queue</h3>
-                              <p class="card-pf-utilization-details">
-                                <span class="card-pf-utilization-card-details-count">{{sync_worker_queue_count_total}}</span>
-                                <span class="card-pf-utilization-card-details-line-1"></span>
-                                <span class="card-pf-utilization-card-details-line-2">items processed</span>
-                              </p>
-                              <div class="chart-pf-sparkline" id="chart-pf-sync_worker_queue_count"></div>
-                            </div>
-                          </div>
-                          <div class="row">
-                            <div class="col-xs-12 col-sm-4 col-md-4">
-                              <h3 class="card-pf-subtitle">Pending Worker</h3>
-                              <p class="card-pf-utilization-details">
-                                <span class="card-pf-utilization-card-details-count">{{pending_worker_process_time_ms_avg}}</span>
-                                <span class="card-pf-utilization-card-details-line-1"></span>
-                                <span class="card-pf-utilization-card-details-line-2">ms avg process time</span>
-                              </p>
-                              <div class="chart-pf-sparkline" id="chart-pf-pending_worker_process_time_ms"></div>
-                            </div>
-                            <div class="col-xs-12 col-sm-4 col-md-4">
-                              <h3 class="card-pf-subtitle">Ack Worker</h3>
-                              <p class="card-pf-utilization-details">
-                                <span class="card-pf-utilization-card-details-count">{{ack_worker_process_time_ms_avg}}</span>
-                                <span class="card-pf-utilization-card-details-line-1"></span>
-                                <span class="card-pf-utilization-card-details-line-2">ms avg process time</span>
-                              </p>
-                              <div class="chart-pf-sparkline" id="chart-pf-ack_worker_process_time_ms"></div>
-                            </div>
-                            <div class="col-xs-12 col-sm-4 col-md-4">
-                              <h3 class="card-pf-subtitle">Sync Worker</h3>
-                              <p class="card-pf-utilization-details">
-                                <span class="card-pf-utilization-card-details-count">{{sync_worker_process_time_ms_avg}}</span>
-                                <span class="card-pf-utilization-card-details-line-1"></span>
-                                <span class="card-pf-utilization-card-details-line-2">ms avg process time</span>
-                              </p>
-                              <div class="chart-pf-sparkline" id="chart-pf-sync_worker_process_time_ms"></div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                      
-                      <div class="card-pf card-pf-utilization">
-                        <div class="card-pf-heading">
-                          <p class="card-pf-heading-details">Last 30 readings</p>
-                          <h2 class="card-pf-title">
-                            Timings (milliseconds)
-                          </h2>
-                        </div>
-                        <div class="card-pf-body">
-                          <div class="row">
-                            <div class="col-12">
-                              <div class="col-12mcp-dashboard-chart">
-                                <div id="line-chart-timings" class="line-chart-pf"></div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div ng-if="charts.length == 0">
+                    <div ng-if="chartData.length == 0">
                       <div class="empty-state-message text-center">
                         <h2>No Stats currently available for this service</h2>
                       </div>

--- a/ui/public/views/service-details.template.html
+++ b/ui/public/views/service-details.template.html
@@ -1,0 +1,9 @@
+<h2 class="dashboard-details">Details</h2>
+<dl class="dl-horizontal left">
+  <dt>Description:</dt>
+  <dd>{{ service.description }}</dd>
+  <dt>Dashboard URL:</dt>
+  <dd><a href="{{ service.host }}">{{service.host}}</a></dd>
+  <dt ng-repeat-start="(key, value) in service.params">{{ key }}</dt>
+  <dd ng-repeat-end>{{ value }}</dd>
+</dl>


### PR DESCRIPTION
@david-martin The refactoring of the service charts.

**Sync charts**

![queues-and-workers](https://user-images.githubusercontent.com/22113654/32009498-3728d954-b9a7-11e7-8f37-84c7dfbf438c.png)
![qandw-empty](https://user-images.githubusercontent.com/22113654/32009508-3e1d5da2-b9a7-11e7-9b3b-6b636ecccf69.png)
![sync-timings](https://user-images.githubusercontent.com/22113654/32009536-5078f2d6-b9a7-11e7-965d-f0a148853335.png)
![sync-timings-empty](https://user-images.githubusercontent.com/22113654/32009554-58fa7790-b9a7-11e7-96da-370b098cbb8c.png)

**Keycloak charts**

![keycloak-component](https://user-images.githubusercontent.com/22113654/32009583-6537ec2c-b9a7-11e7-9747-ce629485e163.png)

**Default charts**

![default-line-graph](https://user-images.githubusercontent.com/22113654/32009604-6edb0eda-b9a7-11e7-8c63-497b531f6e52.png)


