### PR TITLE
Implement GenericClientConfig

### DIFF
--- a/pkg/data/mobileService.go
+++ b/pkg/data/mobileService.go
@@ -63,7 +63,9 @@ type syncSecretConvertor struct{}
 
 //Convert a kubernetes Sync Server secret into a keycloak mobile.ServiceConfig
 func (scc syncSecretConvertor) Convert(s v1.Secret) (*mobile.ServiceConfig, error) {
-	config := map[string]interface{}{}
+	config := map[string]interface{}{
+		"uri": string(s.Data["uri"]),
+	}
 	headers := map[string]string{}
 
 	acAppID, acAppIDExists := s.Data["apicast_app_id"]

--- a/pkg/mobile/integration/serviceConfig_test.go
+++ b/pkg/mobile/integration/serviceConfig_test.go
@@ -54,7 +54,7 @@ func TestSDKService_GenerateMobileServiceConfigs(t *testing.T) {
 					t.Fatal("expected sdk configs but got none")
 				}
 				if v, ok := sdkConfigs["fh-sync-server"]; ok {
-					if _, ok := v.Config.ConfigParams["uri"]; !ok {
+					if _, ok := v.Config["uri"]; !ok {
 						t.Fatalf("expected a uri in the service config")
 					}
 				} else {

--- a/pkg/mobile/integration/serviceConfig_test.go
+++ b/pkg/mobile/integration/serviceConfig_test.go
@@ -54,8 +54,7 @@ func TestSDKService_GenerateMobileServiceConfigs(t *testing.T) {
 					t.Fatal("expected sdk configs but got none")
 				}
 				if v, ok := sdkConfigs["fh-sync-server"]; ok {
-					configValues := v.Config.(map[string]string)
-					if _, ok := configValues["uri"]; !ok {
+					if _, ok := v.Config.ConfigParams["uri"]; !ok {
 						t.Fatalf("expected a uri in the service config")
 					}
 				} else {

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -160,13 +160,13 @@ type ServiceIntegration struct {
 type ConfigParams map[string]interface{}
 
 type GenericClientConfig struct {
-	ConfigParams `json:"params"`
-	Headers      map[string]string `json:"headers"`
+	ConfigParams
+	Headers map[string]string `json:"headers"`
 }
 
 type ServiceConfig struct {
-	Config *GenericClientConfig `json:"config"`
-	Name   string               `json:"name"`
+	Config map[string]interface{} `json:"config"`
+	Name   string                 `json:"name"`
 }
 
 type AttrFilterFunc func(attrs Attributer) bool

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -157,21 +157,16 @@ type ServiceIntegration struct {
 	DisplayName     string `json:"displayName"`
 }
 
-type ServiceConfig struct {
-	Config interface{} `json:"config"`
-	Name   string      `json:"name"`
+type ConfigParams map[string]interface{}
+
+type GenericClientConfig struct {
+	ConfigParams `json:"params"`
+	Headers      map[string]string `json:"headers"`
 }
 
-type KeycloakConfig struct {
-	SSLRequired   string `json:"ssl-required"`
-	AuthServerURL string `json:"auth-server-url"`
-	Realm         string `json:"realm"`
-	Resource      string `json:"resource"`
-	ClientID      string `json:"clientId"`
-	URL           string `json:"url"`
-	Credentials   struct {
-		Secret string `json:"secret"`
-	} `json:"credentials"`
+type ServiceConfig struct {
+	Config *GenericClientConfig `json:"config"`
+	Name   string               `json:"name"`
 }
 
 type AttrFilterFunc func(attrs Attributer) bool


### PR DESCRIPTION
@maleck13 Would you mind taking a look? This changes the response from the SDK config endpoint a bit from:

```json
{
    "name": "servicename",
    "config": { "uri": "https://servicename" }
}
```

to

```json
{
    "name": "servicename",
    "config": {
        "params": { "uri": "https://servicename" },
        "headers": { "app_key": "test", "app_id": "test" }
    }
}
```

So we'll need to update the sample app, but not the core SDK.