### PR TITLE
🐛 Lock down origin images to have a stable local cluster

### DIFF
--- a/installer/roles/oc-cluster-up/defaults/main.yml
+++ b/installer/roles/oc-cluster-up/defaults/main.yml
@@ -7,6 +7,8 @@ hawkular_metrics: "false"
 
 host_config_dir: "{{playbook_dir}}/../ui"
 
-cluster_version: latest
+cluster_image: feedhenry/origin
+
+cluster_version: 3.7
 
 cluster_public_hostname: "192.168.37.1"

--- a/installer/roles/oc-cluster-up/tasks/main.yml
+++ b/installer/roles/oc-cluster-up/tasks/main.yml
@@ -80,7 +80,7 @@
     - public_hostname != ''
 
   - set_fact:
-      cluster_up_command: "{{ cluster_up_command }} --version={{ cluster_version }}"
+      cluster_up_command: "{{ cluster_up_command }} --version={{ cluster_version }} --image={{ cluster_image }}"
     when:
     - cluster_version is defined
     - cluster_version != ''


### PR DESCRIPTION
This change tells 'oc cluster' to use a specific tag and specific set of
images for origin i.e. the '3.7' tag in the dockerhub 'feedhenry' org.