### PR TITLE
Remove keycloak metrics protocol

### DIFF
--- a/pkg/mobile/metrics/keycloak.go
+++ b/pkg/mobile/metrics/keycloak.go
@@ -58,7 +58,7 @@ func (kc *Keycloak) Gather() ([]*metric, error) {
 	}
 	kcService := kcServices[0] //TODO deal with more than one
 	//TODO get protocol from secret
-	host := "http://" + kcService.Host
+	host := kcService.Host
 	username := kcService.Params["admin_username"]
 	pass := kcService.Params["admin_password"]
 	realm := kcService.Params["realm"]


### PR DESCRIPTION
@david-martin Would you mind taking a look? Related to this line in your PR https://github.com/feedhenry/keycloak-apb/pull/23/files#diff-f6f4a5c554add33c75151ab6f477659cR12 .

The host is currently `http://http://example-keycloak.com`