### PR TITLE
remove unneeded service from returned config

### DIFF
--- a/pkg/data/mobileService.go
+++ b/pkg/data/mobileService.go
@@ -28,12 +28,27 @@ type MobileServiceValidator interface {
 // defaultSecretConvertor will provide a default secret to config conversion
 type defaultSecretConvertor struct{}
 
+type ignoredFields []string
+
+func (i ignoredFields) Contains(field string) bool {
+	for _, f := range i {
+		if field == f {
+			return true
+		}
+	}
+	return false
+}
+
+var ignored = ignoredFields{"password", "token"}
+
 //Convert a kubernetes secret to a mobile.ServiceConfig
 func (dsc defaultSecretConvertor) Convert(s v1.Secret) (*mobile.ServiceConfig, error) {
 	config := map[string]interface{}{}
 	headers := map[string]string{}
 	for k, v := range s.Data {
-		config[k] = string(v)
+		if !ignored.Contains(k) {
+			config[k] = string(v)
+		}
 	}
 	config["headers"] = headers
 	return &mobile.ServiceConfig{

--- a/pkg/mobile/integration/serviceConfig.go
+++ b/pkg/mobile/integration/serviceConfig.go
@@ -10,7 +10,7 @@ type SDKService struct{}
 
 // GenerateMobileServiceConfigs will return a map of services and their mobile configs
 func (ms *SDKService) GenerateMobileServiceConfigs(serviceCruder mobile.ServiceCruder) (map[string]*mobile.ServiceConfig, error) {
-	svcConfigs, err := serviceCruder.ListConfigs(filterServices(mobile.ValidServiceTypes))
+	svcConfigs, err := serviceCruder.ListConfigs(filterServices(mobile.ValidClientConfigServices))
 	if err != nil {
 		return nil, errors.Wrap(err, "GenerateMobileServiceConfigs failed during a list of configs")
 	}

--- a/pkg/mobile/integration/serviceConfig_test.go
+++ b/pkg/mobile/integration/serviceConfig_test.go
@@ -63,6 +63,43 @@ func TestSDKService_GenerateMobileServiceConfigs(t *testing.T) {
 			},
 		},
 		{
+			Name: "test generate service configs does not return 3scale",
+			Client: func() mobile.ServiceCruder {
+				client := &fake.Clientset{}
+				client.AddReactor("list", "secrets", func(a ktesting.Action) (bool, runtime.Object, error) {
+					list := v1.SecretList{
+						Items: []v1.Secret{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{"group": "mobileapp"},
+								},
+								Data: map[string][]byte{
+									"uri":  []byte("http://fh-sync.com"),
+									"name": []byte(mobile.ServiceNameThreeScale),
+									"type": []byte(mobile.ServiceNameThreeScale),
+								},
+							},
+							{
+								Data: map[string][]byte{
+									"uri": []byte("http://somehost.com"),
+								},
+							},
+						},
+					}
+					return true, &list, nil
+				})
+				return data.NewMobileServiceRepo(client.CoreV1().Secrets("test"))
+			},
+			Validate: func(sdkConfigs map[string]*mobile.ServiceConfig, t *testing.T) {
+				if nil == sdkConfigs {
+					t.Fatal("expected sdk configs but got none")
+				}
+				if _, ok := sdkConfigs[mobile.ServiceNameThreeScale]; ok {
+					t.Fatal("did not expect " + mobile.ServiceNameThreeScale + " to be returned")
+				}
+			},
+		},
+		{
 			Name: "test generate service config fails on error",
 			Client: func() mobile.ServiceCruder {
 				client := &fake.Clientset{}

--- a/pkg/mobile/integration/serviceConfig_test.go
+++ b/pkg/mobile/integration/serviceConfig_test.go
@@ -74,7 +74,7 @@ func TestSDKService_GenerateMobileServiceConfigs(t *testing.T) {
 									Labels: map[string]string{"group": "mobileapp"},
 								},
 								Data: map[string][]byte{
-									"uri":  []byte("http://fh-sync.com"),
+									"uri":  []byte("http://3scale.com"),
 									"name": []byte(mobile.ServiceNameThreeScale),
 									"type": []byte(mobile.ServiceNameThreeScale),
 								},

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -213,6 +213,7 @@ func (st ServiceTypes) Contains(service string) bool {
 }
 
 var ValidServiceTypes = ServiceTypes{ServiceNameKeycloak, ServiceNameThreeScale, ServiceNameSync, ServiceNameMobileCICD, ServiceNameCustom}
+var ValidClientConfigServices = ServiceTypes{ServiceNameKeycloak, ServiceNameSync, ServiceNameCustom}
 var ValidServicesAndIntegrations = ServiceTypes{ServiceNameKeycloak, ServiceNameThreeScale, ServiceNameSync, ServiceNameMobileCICD, ServiceNameCustom, IntegrationAPIKeys}
 
 const (


### PR DESCRIPTION
removed sensitive info from general configs and excludes unneeded services from being returned to the client