### PR TITLE
Remove log from CLI to allow for piping

### DIFF
--- a/pkg/cli/cmd/sdkconfig.go
+++ b/pkg/cli/cmd/sdkconfig.go
@@ -43,7 +43,6 @@ var getsdkconfigCmd = &cobra.Command{
 			log.Fatalf("error parsing mcp host %s ", err)
 		}
 		u.Path = path.Join(u.Path, fmt.Sprintf("/sdk/mobileapp/%s/config", app.ID))
-		fmt.Println("url is ", u.String())
 		req, err := http.NewRequest("GET", u.String(), nil)
 		if err != nil {
 			log.Fatalf("error creating request %s ", err)


### PR DESCRIPTION
Currently we log out 'url is' when performing a 'mcp get sdkconfig'
command. This output means that the resulting JSON output that
comes after the log cannot be piped directly into something like
'jq' which would be useful.