### PR TITLE
Clean up after modal $destroy

### DIFF
--- a/ui/public/scripts/shared/mp-modal.directive.js
+++ b/ui/public/scripts/shared/mp-modal.directive.js
@@ -107,6 +107,10 @@ angular.module('mobileControlPanelApp').directive('mpModal', [
               $('.modal-backdrop').remove();
             }
           });
+
+          scope.$watch('$destroy', function() {
+            $('.modal.container').remove();
+          });
         });
       }
     };


### PR DESCRIPTION
@david-martin 

When we transition from the `get-started` component to the service overview component we destroy a modal directive and create a new instance leading to a stale reference.
- Adding in some cleanup on modal `$destroy` to remove modal references in the DOM