### PR TITLE
Note for macOS users (ansible roles path)

### DIFF
--- a/docs/walkthroughs/local-setup.adoc
+++ b/docs/walkthroughs/local-setup.adoc
@@ -53,6 +53,9 @@ is not essential.
 ----
 ansible-galaxy install -r ./installer/requirements.yml
 ----
+*Note (macOS):* If you're using `ansible` installed via `pip`, you may need create 
+a special folder for ansible-roles and run this command with `--roles-path <ansible-roles-folder-path>`,
+or run it with `sudo`. This is because non-root user does not have write access to default ansible roles folder (`/etc/ansible/roles`).
 
 [[firewall-setup]]
 === Configure the Firewall


### PR DESCRIPTION
This docs addition is based on the issue I encountered when using `ansible` installed with `pip`
```
ansible-galaxy install -r ./installer/requirements.yml
- downloading role 'openshift-origin-client-tools', owned by andrewrothstein
- downloading role from https://github.com/andrewrothstein/ansible-openshift-origin-client-tools/archive/v1.0.3.tar.gz
- extracting openshift-origin-client-tools to /etc/ansible/roles/openshift-origin-client-tools
 [WARNING]: - openshift-origin-client-tools was NOT installed successfully: Could not update files in /etc/ansible/roles/openshift-origin-client-
tools: [Errno 13] Permission denied: '/etc/ansible/roles/openshift-origin-client-tools'

ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
```