### PR TITLE
💄 Update the selector classes to fix mobile icon size in nav

### DIFF
--- a/ui/public/styles/mp-mobile-extension-tab.less
+++ b/ui/public/styles/mp-mobile-extension-tab.less
@@ -1,6 +1,6 @@
 /* Mobile Control Panel Extension CSS */
 @media (min-width: 768px) {
-  .sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li>a .fa-mobile {
+  .nav-pf-vertical .list-group-item>a .fa-mobile {
     font-size: 25px;
     padding-bottom: 0;
     vertical-align: middle;


### PR DESCRIPTION
The origin web console nav has changed to a patternfly nav (see https://github.com/openshift/origin-web-console/pull/1932), which broke a css selector in the MCP UI extension.

This change fixes the selector for increasing the mobile icon size.

Before:
![image](https://user-images.githubusercontent.com/878251/32940365-5c69ed40-cb7a-11e7-8d93-8756bf50edf4.png)

After:
![image](https://user-images.githubusercontent.com/878251/32940372-61795b68-cb7a-11e7-95c6-5def3d783f9d.png)
