### PR TITLE
[WIP] Use previous oc dir for new oc

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -159,6 +159,8 @@ function check_oc() {
 function read_oc_install_dir() {
   read -p "Where do you want to install oc? (Defaults to ${oc_install_dir}): " user_oc_install_dir
   oc_install_dir=${user_oc_install_dir:-${oc_install_dir}}
+  echo "Updating PATH to include specified directory"
+  export PATH="${oc_install_dir}:${PATH}"
 }
 
 function run_installer() {

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -18,6 +18,7 @@ echo ' |_|  |_|\____|_|'
 echo ''
 }
 
+oc_install_dir="/usr/local/bin"
 oc_version_comparison=${VER_LT}
 
 # Returns:
@@ -144,6 +145,7 @@ function check_oc() {
       read -p "Allow the installer to delete and reinstall the OpenShift client tools? (y/n): " uninstall_client_tools
       if [[ ${uninstall_client_tools} == "y" ]]; then
         echo "Removing oc tool"
+        oc_install_dir=$(dirname $(command -v oc))
         rm $(command -v oc)
       else
         echo -e "${RED}The Mobile Control Panel requires oc >= 3.7"
@@ -152,6 +154,11 @@ function check_oc() {
     fi
     check_passed_msg "OpenShift Client Tools"
   fi
+}
+
+function read_oc_install_dir() {
+  read -p "Where do you want to install oc? (Defaults to ${oc_install_dir}): " user_oc_install_dir
+  oc_install_dir=${user_oc_install_dir:-${oc_install_dir}}
 }
 
 function run_installer() {
@@ -192,7 +199,7 @@ function run_installer() {
     echo "Skipping OpenShift client tools installation..."
     ansible-playbook installer/playbook.yml -e "dockerhub_username=${dockerhub_username}" -e "dockerhub_password=${dockerhub_password}" -e "dockerhub_tag=${dockerhub_tag}" --skip-tags "install-oc" --ask-become-pass
   else
-    ansible-playbook installer/playbook.yml -e "dockerhub_username=${dockerhub_username}" -e "dockerhub_password=${dockerhub_password}" -e "dockerhub_tag=${dockerhub_tag}" --ask-become-pass
+    ansible-playbook installer/playbook.yml -e "dockerhub_username=${dockerhub_username}" -e "dockerhub_password=${dockerhub_password}" -e "dockerhub_tag=${dockerhub_tag}" -e "oc_install_parent_dir=${oc_install_dir}" --ask-become-pass
   fi
 }
 
@@ -202,4 +209,7 @@ check_npm
 check_python
 check_ansible
 check_oc
+if [[ ${oc_version_comparison} -eq ${VER_LT} ]]; then
+  read_oc_install_dir
+fi
 run_installer

--- a/installer/roles/ansible-service-broker-setup/tasks/main.yml
+++ b/installer/roles/ansible-service-broker-setup/tasks/main.yml
@@ -69,3 +69,13 @@
 
 - debug:
     msg: "{{ oc_cluster_status.stdout_lines }}"
+
+- block:
+  - debug:
+      msg:
+      - "{{ oc_install_parent_dir }}/oc was used to create your cluster."
+      - Ensure that {{ oc_install_parent_dir }} is on your PATH.
+      - If it's not, run export PATH={{ oc_install_parent_dir }}:$PATH, to persist this PATH do
+      - echo 'export PATH={{ oc_install_parent_dir }}:$PATH' >> ~/.bash_profile
+  when:
+  - oc_install_parent_dir is defined

--- a/installer/roles/oc-cluster-up/tasks/main.yml
+++ b/installer/roles/oc-cluster-up/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: Check oc version
+  shell: oc version | sed -n "1p"
+  register: oc_prereq_check
+
+- fail: msg="oc client tools are < 3.7, install oc >= 3.7"
+  when: oc_prereq_check.stdout.find("v3.7") == -1
+
 - name: Create alias for lo0 (macos)
   shell: ifconfig lo0 alias {{ cluster_public_hostname }}
   become: yes


### PR DESCRIPTION
@maleck13 Would you mind taking a look?

There are two main changes here. One in the interactive-y `installer/install.sh` script that will ask where you want to install the new `oc` binary. If there was a previous `oc` then it will default to that directory. It knows that will definitely cause the correct binary to be executed when `oc` is called. So the flow goes something like this:

* User has `oc v3.6` at `/some/strange/dir/oc`
* User runs `installer/install.sh`
* `installer/install.sh` prompts for removal of `oc`
* `installer/install.sh` asks where to install the new `oc`, defaults to `/some/strange/dir/`

The second change is in the Ansible installer, which just performs a basic check and bails out with an error message if `oc` is not the correct version.

There is also a PR up at (https://github.com/andrewrothstein/ansible-openshift-origin-client-tools) to resolve another case where a new `oc` won't be installed by the Ansible installer under certain circumstances.

I'll leave this open until that is merged and make the needed changes here after it's merged. 

This resolves #221 