### PR TITLE
Setup admin user with cluster edit permissions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -112,3 +112,9 @@ Effectively all you need to do is add the dockerhub_tag to your install command.
 make clean
 ansible-playbook playbook.yml -e "dockerhub_username=$DOCKERHUB_USERNAME" -e "dockerhub_tag=${TAG}" -e "dockerhub_password=$DOCKERHUB_PASSWORD" -e "dockerhub_org=$DOCKERHUB_APBS_ORG" -e "skip_apb=keycloak-apb" --ask-become-pass
 ....
+
+By default an `admin` user will be created with cluster edit permissions. To skip creating this user use `--tags=local` with the installer. For example:
+
+```
+ansible-playbook playbook.yml -e "dockerhub_username=$DOCKERHUB_USERNAME" -e "dockerhub_tag=${TAG}" -e "dockerhub_password=$DOCKERHUB_PASSWORD" -e "dockerhub_org=$DOCKERHUB_APBS_ORG" --tags=local --ask-become-pass
+```

--- a/installer/playbook.yml
+++ b/installer/playbook.yml
@@ -12,15 +12,18 @@
   #   tags: install-oc
 
   - role: oc-cluster-up
-    tags: oc-cluster-up
+    tags: [oc-cluster-up, local, local-dev]
 
   - role: template-service-broker-setup
-    tags: setup-tsb
+    tags: [setup-tsb, local, local-dev]
 
   - role: mcp-ui-extension-setup
-    tags: setup-mcp
+    tags: [setup-mcp, local, local-dev]
+
+  - role: setup-openshift-admin-user
+    tags: [setup-admin-user, local-dev]
 
   - role: ansible-service-broker-setup
-    tags: setup-asb
+    tags: [setup-asb, local, local-dev]
   vars_files:
   - "vars/mobile-control-panel.yml"

--- a/installer/roles/setup-openshift-admin-user/defaults/main.yml
+++ b/installer/roles/setup-openshift-admin-user/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for setup-openshift-admin-user
+
+user_name: admin

--- a/installer/roles/setup-openshift-admin-user/tasks/main.yml
+++ b/installer/roles/setup-openshift-admin-user/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+# tasks file for setup-openshift-admin-user
+
+- name: Login as system admin
+  shell: "oc login -u system:admin"
+  register: oc_system_admin_login
+
+- name: Create admin user
+  shell: "oc create user {{ user_name }}"
+  register: oc_create_user
+
+- name: Give admin user permissions
+  shell: "oc adm policy add-cluster-role-to-user edit {{ user_name }}"
+  register: oc_user_policy


### PR DESCRIPTION
Currently we have to create this user manually. This change adds a
role that will create a user named admin and give it cluster edit
permissions.

A further change has been made to provide additional labels in the
playbook file to differentiate between what should be done for
normal local installations and local dev installations.

When running the playbook with --tags=local the admin user will not
be created. It will with local-dev.

Resolves #184