### PR TITLE
Community health index

### DIFF
--- a/.github/CODE_OF_CONDUCT
+++ b/.github/CODE_OF_CONDUCT
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at feedhenry-raincatcher@redhat.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CODE_OF_CONDUCT
+++ b/.github/CODE_OF_CONDUCT
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at feedhenry-raincatcher@redhat.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at feedhenry-dev@redhat.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,32 +1,24 @@
 # How to contribute
 
-Thank you for your interest in contributing to the FeedHenry project. We want to
-keep this process as easy as possible so we've outlined a few guidelines below.
-For more information about the FeedHenry project, visit
+Thank you for your interest in contributing to the FeedHenry project. We want
+keep this process as easy as possible so we've outlined a few guidelines below. 
+For more information about the FeedHenry project, visit 
 [our website](http://feedhenry.org/).
 
 ## Asking for help
 
 Whether you're contributing a new feature or bug fix, or simply submitting a
-ticket, the RainCatcher team is available for technical advice or feedback.
-You can reach us at [gitter chat](https://gitter.im/FeedhenryRaincatcher/Lobby) or the
-[feedhenry-raincatcher list](https://www.redhat.com/mailman/listinfo/feedhenry-raincatcher)
+ticket, the FeedHenry team is available for technical advice or feedback. 
+You can reach us at #feedhenry on [Freenode IRC](https://freenode.net/) or the 
+[feedhenry-dev list](https://www.redhat.com/mailman/listinfo/feedhenry-dev) 
 -- both are actively monitored.
-
-
-## Best practices
-
-- Bugfixes should only contain changes that are related to the purpose of the bug.
-- Description should contain an explanation for the proposed changes.
-- It's recommended to consult feature requests with the team before starting implementation
-- Send us a message on chat or email if you need assistance with any work. 
 
 ## Getting started
 
 * Make sure you have a [JIRA account](https://issues.jboss.org)
 * Make sure you have a [GitHub account](https://github.com/signup/free)
-* Submit a ticket for your issue to the
-[RainCatcher project](https://issues.jboss.org/projects/RAINCATCH/), assuming one does
+* Submit a ticket for your issue to the 
+[FeedHenry project](https://issues.jboss.org/projects/FH/), assuming one does 
 not already exist.
   * Clearly describe the issue including steps to reproduce when it is a bug.
   * Make sure you fill in the earliest version that you know has the issue.
@@ -37,11 +29,11 @@ not already exist.
 * Create a topic branch from where you want to base your work.
   * This is usually the master branch.
   * To quickly create a topic branch based on master; `git checkout -b
-    <branch name> master`. By convention we typically include the JIRA issue
-    key in the branch name, e.g. `RAINCATCH-1234-my-feature`.
+    <branch name> master`. By convention we typically include the JIRA issue 
+    key in the branch name, e.g. `FH-1234-my-feature`.
   * Please avoid working directly on the `master` branch.
 * Make commits of logical units.
-* Prepend your commit messages with a JIRA ticket number, e.g. "RAINCATCH-1234: Fix
+* Prepend your commit messages with a JIRA ticket number, e.g. "FH-1234: Fix
   spelling mistake in README."
 * Follow the coding style in use.
 * Check for unnecessary whitespace with `git diff --check` before committing.
@@ -51,25 +43,25 @@ not already exist.
 ## Submitting changes
 
 * Push your changes to a topic branch in your fork of the repository.
-* Submit a pull request to the repository in the [RainCatcher GitHub organization]
-  (https://github.com/feedhenry-raincatcher) and choose branch you want to patch
-  (usually master).
-  * Advanced users may want to install the [GitHub CLI](https://hub.github.com/)
+* Submit a pull request to the repository in the [FeedHenry GitHub organization]
+  (https://github.com/feedhenry) and choose branch you want to patch 
+  (usually master). 
+  * Advanced users may want to install the [GitHub CLI](https://hub.github.com/) 
     and use the `hub pull-request` command.
-* Update your JIRA ticket to mark that you have submitted code and are ready
+* Update your JIRA ticket to mark that you have submitted code and are ready 
 for it to be reviewed (Status: Dev Complete).
   * Include a link to the pull request in the ticket.
-* Add detail about the change to the pull request including screenshots
+* Add detail about the change to the pull request including screenshots 
   if the change affects the UI.
 
 ## Reviewing changes
 
 * After submitting a pull request, one of FeedHenry team members will review it.
-* Changes may be requested to conform to our style guide and internal
+* Changes may be requested to conform to our style guide and internal 
   requirements.
 * When the changes are approved and all tests are passing, a FeedHenry team
   member will merge them.
-* Note: if you have write access to the repository, do not directly merge pull
+* Note: if you have write access to the repository, do not directly merge pull 
   requests. Let another team member review your pull request and approve it.
 
 ## Coding best practices

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# How to contribute
+
+Thank you for your interest in contributing to the FeedHenry project. We want to
+keep this process as easy as possible so we've outlined a few guidelines below.
+For more information about the FeedHenry project, visit
+[our website](http://feedhenry.org/).
+
+## Asking for help
+
+Whether you're contributing a new feature or bug fix, or simply submitting a
+ticket, the RainCatcher team is available for technical advice or feedback.
+You can reach us at [gitter chat](https://gitter.im/FeedhenryRaincatcher/Lobby) or the
+[feedhenry-raincatcher list](https://www.redhat.com/mailman/listinfo/feedhenry-raincatcher)
+-- both are actively monitored.
+
+
+## Best practices
+
+- Bugfixes should only contain changes that are related to the purpose of the bug.
+- Description should contain an explanation for the proposed changes.
+- It's recommended to consult feature requests with the team before starting implementation
+- Send us a message on chat or email if you need assistance with any work. 
+
+## Getting started
+
+* Make sure you have a [JIRA account](https://issues.jboss.org)
+* Make sure you have a [GitHub account](https://github.com/signup/free)
+* Submit a ticket for your issue to the
+[RainCatcher project](https://issues.jboss.org/projects/RAINCATCH/), assuming one does
+not already exist.
+  * Clearly describe the issue including steps to reproduce when it is a bug.
+  * Make sure you fill in the earliest version that you know has the issue.
+* Fork the repository on GitHub.
+
+## Making changes
+
+* Create a topic branch from where you want to base your work.
+  * This is usually the master branch.
+  * To quickly create a topic branch based on master; `git checkout -b
+    <branch name> master`. By convention we typically include the JIRA issue
+    key in the branch name, e.g. `RAINCATCH-1234-my-feature`.
+  * Please avoid working directly on the `master` branch.
+* Make commits of logical units.
+* Prepend your commit messages with a JIRA ticket number, e.g. "RAINCATCH-1234: Fix
+  spelling mistake in README."
+* Follow the coding style in use.
+* Check for unnecessary whitespace with `git diff --check` before committing.
+* Make sure you have added the necessary tests for your changes.
+* Run _all_ the tests to assure nothing else was accidentally broken.
+
+## Submitting changes
+
+* Push your changes to a topic branch in your fork of the repository.
+* Submit a pull request to the repository in the [RainCatcher GitHub organization]
+  (https://github.com/feedhenry-raincatcher) and choose branch you want to patch
+  (usually master).
+  * Advanced users may want to install the [GitHub CLI](https://hub.github.com/)
+    and use the `hub pull-request` command.
+* Update your JIRA ticket to mark that you have submitted code and are ready
+for it to be reviewed (Status: Dev Complete).
+  * Include a link to the pull request in the ticket.
+* Add detail about the change to the pull request including screenshots
+  if the change affects the UI.
+
+## Reviewing changes
+
+* After submitting a pull request, one of FeedHenry team members will review it.
+* Changes may be requested to conform to our style guide and internal
+  requirements.
+* When the changes are approved and all tests are passing, a FeedHenry team
+  member will merge them.
+* Note: if you have write access to the repository, do not directly merge pull
+  requests. Let another team member review your pull request and approve it.
+
+## Coding best practices
+
+We have compiled a set of best practices for each programming
+language we use. View them [here](https://github.com/fheng/best_practice).
+
+# Additional Resources
+
+* [General GitHub documentation](http://help.github.com/)
+* [GitHub pull request documentation](https://help.github.com/articles/about-pull-requests/)
+* [Read the Issue Guidelines by @necolas](https://github.com/necolas/issue-guidelines/blob/master/CONTRIBUTING.md) for more details

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Description
+
+## Environment
+
+*Operating system*:
+*OpenShift versions*: 
+
+## Steps to reproduce

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Motivation
+
+## Description
+A few sentences describing the overall goals of the pull request's commits.
+
+## Progress
+- [ ]
+- [ ] Unit tests
+- [ ] Documentation
+
+## Additional Notes
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,9 @@
 A few sentences describing the overall goals of the pull request's commits.
 
 ## Progress
-- [ ]
-- [ ] Unit tests
-- [ ] Documentation
+
+- [x] Finished task
+- [ ] TODO
 
 ## Additional Notes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ A few sentences describing the overall goals of the pull request's commits.
 ## Progress
 
 - [x] Finished task
-- [ ] TODO
+- [] TODO
 
 ## Additional Notes
 


### PR DESCRIPTION
## Motivation

Add standard github documents and templates. 

Each file is pushed as separate commit and it can be reviewed or rejected.
This change will help to tick all the boxes in the community profile.
<img width="751" alt="screen shot 2017-11-29 at 9 40 51 am" src="https://user-images.githubusercontent.com/981838/33368419-903a07c2-d4e9-11e7-97ff-f19ba6ebac03.png">

It's worth having this +more than 20 github stars to raise project profile. 

## Suggestions

Additionally developers can add CODEOWNERS for assigning reviewers for specific parts of the code. 
