### PR TITLE
Allow to configure nip.io

### DIFF
--- a/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
+++ b/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
@@ -6,6 +6,7 @@ readonly DOCKERHUB_PASS="${2}"
 readonly DOCKERHUB_ORG="${3}"
 readonly LAUNCH_APB_ON_BIND="${4}"
 readonly TAG="${5}"
+readonly WILDCARD_DNS="${6}"
 
 echo "starting install of ansible service broker"
 
@@ -32,7 +33,7 @@ oc process -f "${TEMPLATE_LOCAL}" \
 -p BROKER_IMAGE="ansibleplaybookbundle/origin-ansible-service-broker:sprint139.1" \
 -p ENABLE_BASIC_AUTH="false" \
 -p SANDBOX_ROLE="admin" \
--p ROUTING_SUFFIX="192.168.37.1.nip.io" \
+-p ROUTING_SUFFIX="192.168.37.1.${WILDCARD_DNS}" \
 -p TAG="${TAG:-latest}" \
 -p LAUNCH_APB_ON_BIND="${LAUNCH_APB_ON_BIND}" \
 ${TEMPLATE_VARS} | oc create -f -

--- a/installer/roles/ansible-service-broker-setup/tasks/main.yml
+++ b/installer/roles/ansible-service-broker-setup/tasks/main.yml
@@ -40,7 +40,7 @@
       mode: u+x
 
   - name: Execute Ansible Service Broker provision script
-    shell: bash -e /tmp/provision-ansible-service-broker.sh "{{ dockerhub_username }}" "{{ dockerhub_password }}" "{{ dockerhub_org }}" "{{ launch_apb_on_bind }}" "{{dockerhub_tag}}"
+    shell: bash -e /tmp/provision-ansible-service-broker.sh "{{ dockerhub_username }}" "{{ dockerhub_password }}" "{{ dockerhub_org }}" "{{ launch_apb_on_bind }}" "{{dockerhub_tag}}" "{{ wildcard_dns_host }}"
   when:
   - dockerhub_tag is defined
   - dockerhub_tag != ''

--- a/installer/roles/oc-cluster-up/tasks/main.yml
+++ b/installer/roles/oc-cluster-up/tasks/main.yml
@@ -20,7 +20,7 @@
   when: ansible_os_family in ["RedHat", "Debian"]
 
 - set_fact:
-    routing_suffix: "{{ cluster_public_hostname }}.nip.io"
+    routing_suffix: "{{ cluster_public_hostname }}.{{ wildcard_dns_host }}"
     public_hostname: "{{ cluster_public_hostname }}"
 
 - name: Obtain status of oc cluster

--- a/installer/vars/mobile-control-panel.yml
+++ b/installer/vars/mobile-control-panel.yml
@@ -6,3 +6,4 @@ oc_sha: 'e92d5c5'
 oc_checksums:
   linux-64bit: sha256:e35e53b42a00e4d04305ec55c94b623135d3ac236c999c00765703161da23769
   mac: sha256:0f1ec8ad4e84a207e54d526c27daa73bd066f75f14d8f735377132da04acb959
+wildcard_dns_host: nip.io


### PR DESCRIPTION
`wildcard_dns_host` can now be specified as an extra var to Ansible for when `nip.io` goes down. Using, for example, `-e "wildcard_dns_host=xip.io"`