### PR TITLE
allow specifying dockerhub org in installer script

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -194,6 +194,9 @@ function run_installer() {
   read -p "DockerHub Tag (Defaults to latest): " dockerhub_tag
   dockerhub_tag=${dockerhub_tag:-"latest"}
 
+  read -p "DockerHub Orgnisation (Defaults to feedhenry): " dockerhub_org
+  dockerhub_org=${dockerhub_org:-"feedhenry"}
+
   echo "Performing and clean and running the installer. You will be asked for your password."
 
   cd ${SCRIPT_ABSOLUTE_PATH}
@@ -206,9 +209,9 @@ function run_installer() {
 
   if [[ ${oc_version_comparison} -ne ${VER_LT} ]]; then
     echo "Skipping OpenShift client tools installation..."
-    ansible-playbook installer/playbook.yml -e "dockerhub_username=${dockerhub_username}" -e "dockerhub_password=${dockerhub_password}" -e "dockerhub_tag=${dockerhub_tag}" --skip-tags "install-oc" --ask-become-pass
+    ansible-playbook installer/playbook.yml -e "dockerhub_username=${dockerhub_username}" -e "dockerhub_password=${dockerhub_password}" -e "dockerhub_tag=${dockerhub_tag}" -e "dockerhub_org=${dockerhub_org}" --skip-tags "install-oc" --ask-become-pass
   else
-    ansible-playbook installer/playbook.yml -e "dockerhub_username=${dockerhub_username}" -e "dockerhub_password=${dockerhub_password}" -e "dockerhub_tag=${dockerhub_tag}" -e "oc_install_parent_dir=${oc_install_dir}" --ask-become-pass
+    ansible-playbook installer/playbook.yml -e "dockerhub_username=${dockerhub_username}" -e "dockerhub_password=${dockerhub_password}" -e "dockerhub_tag=${dockerhub_tag}" -e "dockerhub_org=${dockerhub_org}" -e "oc_install_parent_dir=${oc_install_dir}" --ask-become-pass
   fi
 }
 


### PR DESCRIPTION
## Motivation
Cannot change dockerhub_org from feedhenry

## Description
Allow specifying dockerhub_org during the install

## Progress

- [x] Allow input of dockerhub_org during install

## Additional Notes
Tested locally.

